### PR TITLE
Fix import cycle between pkg/core and pkg/core/transport

### DIFF
--- a/doc/IMPORT_CYCLE_FIX.md
+++ b/doc/IMPORT_CYCLE_FIX.md
@@ -1,0 +1,112 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors -->
+# Import Cycle Fix: Core and Transport Package
+
+This document explains the recent fix for the import cycle between the `pkg/core` and `pkg/core/transport` packages.
+
+## Problem Description
+
+An import cycle was present in the codebase between the following packages:
+
+- **core package** (`pkg/core/client.go`): imports `pkg/core/transport` to create a Transport instance
+- **transport package** (`pkg/core/transport/transport.go`): imports `pkg/core/interfaces` to reference the ClientInterface
+
+This circular dependency prevented the code from compiling and caused CI/CD workflows to fail.
+
+## Solution Implemented
+
+We implemented a solution based on the **deferred initialization** pattern with the following components:
+
+1. **DeferredTransport**: 
+   - Added a new struct in the transport package to hold transport configuration
+   - Allows creating transport settings without requiring the client instance
+
+2. **Transport Factory Function**:
+   - Created `InitTransport()` in a new file `pkg/core/transport_init.go`
+   - This function handles creating the transport with deferred initialization
+   - Breaks the import cycle by putting the client-to-transport connection in the core package
+
+3. **Interface-based Design**:
+   - Updated Client struct to use the Transport interface instead of concrete Transport type
+   - Simplified client options to rely on transport initialization in NewClient
+
+## Changes Made
+
+### 1. Updated `pkg/core/transport/transport.go`
+
+Added a DeferredTransport type and supporting functions:
+
+```go
+// DeferredTransport holds the transport configuration until a client is available
+type DeferredTransport struct {
+    Debug  bool
+    Trace  bool
+    Logger *log.Logger
+}
+
+// NewDeferredTransport creates a configuration for a transport that can be attached to a client later
+func NewDeferredTransport(options *Options) *DeferredTransport {
+    // Configuration setup logic
+    return &DeferredTransport{...}
+}
+
+// AttachClient creates a Transport by attaching a client to a DeferredTransport
+func (dt *DeferredTransport) AttachClient(client interfaces.ClientInterface) *Transport {
+    return &Transport{
+        Client: client,
+        Debug:  dt.Debug,
+        Trace:  dt.Trace,
+        Logger: dt.Logger,
+    }
+}
+```
+
+### 2. Created `pkg/core/transport_init.go`
+
+Created a new file to handle transport initialization:
+
+```go
+// InitTransport initializes a transport for a client
+// This function helps break the import cycle between core and transport packages
+func InitTransport(client interfaces.ClientInterface, debug, trace bool) interfaces.Transport {
+    // Create deferred transport first
+    dt := transport.NewDeferredTransport(&transport.Options{
+        Debug:  debug,
+        Trace:  trace,
+        Logger: loggerForTransport,
+    })
+    
+    // Now attach the client to create the actual transport
+    return dt.AttachClient(client)
+}
+```
+
+### 3. Updated `pkg/core/client.go`
+
+- Removed import of `github.com/scttfrdmn/globus-go-sdk/pkg/core/transport`
+- Changed `Transport` field type from `*transport.Transport` to `interfaces.Transport`
+- Updated `NewClient()` to use `InitTransport()` function
+- Simplified HTTP debugging and tracing options
+
+## Advantages of This Approach
+
+1. **No Import Cycle**: The circular dependency has been eliminated
+2. **Interface-based Design**: Code now depends on interfaces rather than concrete implementations
+3. **Better Testability**: Easier to create mock transports for testing
+4. **Cleaner Separation**: Clear boundaries between packages
+5. **Minimally Invasive**: No major refactoring required in the rest of the codebase
+
+## How It Works
+
+The key insight is pushing the integration code (creating the Transport with a Client) into the package that already has visibility of both types. By creating a "deferred" transport configuration in the transport package, we can later attach the client in the core package without directly importing the concrete Transport type.
+
+## Testing
+
+To verify this fix:
+1. Run `go build ./pkg/...` to ensure compilation works
+2. Run the unit tests for both packages to ensure functionality 
+3. Enable GitHub Actions workflows to verify CI/CD passes
+
+## Related Work
+
+For more comprehensive information about import cycle resolution in this project, see [IMPORT_CYCLE_RESOLUTION.md](IMPORT_CYCLE_RESOLUTION.md).

--- a/doc/REMAINING_FIXES.md
+++ b/doc/REMAINING_FIXES.md
@@ -1,0 +1,119 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors -->
+# Remaining Issues After Import Cycle Fix
+
+This document outlines the remaining issues that need to be addressed after fixing the import cycle between `pkg/core` and `pkg/core/transport`.
+
+## Current Status
+
+The primary import cycle between `pkg/core` and `pkg/core/transport` has been fixed. We can now successfully build:
+
+```bash
+go build ./pkg/core/...
+go build ./pkg/core/transport/...
+```
+
+However, there are still issues when building the entire package:
+
+```bash
+go build ./pkg/...
+```
+
+## Remaining Issues
+
+### 1. Auth Client API Changes
+
+The auth client constructor has been updated to use a functional options pattern, but not all code has been updated to use this new API.
+
+In `pkg/globus.go` line 58:
+```go
+authClient := auth.NewClient(c.ClientID, c.ClientSecret)
+```
+
+Needs to be updated to match the new API that returns a client and an error:
+```go
+authClient, err := auth.NewClient(auth.WithClientID(c.ClientID), auth.WithClientSecret(c.ClientSecret))
+if err != nil {
+    // Handle error
+}
+```
+
+### 2. Missing Client Options in Auth Package
+
+The auth package needs to define options like `WithClientID` and `WithClientSecret` to support the functional options pattern:
+
+```go
+// WithClientID sets the client ID
+func WithClientID(clientID string) ClientOption {
+    return func(c *Client) {
+        c.ClientID = clientID
+    }
+}
+
+// WithClientSecret sets the client secret
+func WithClientSecret(clientSecret string) ClientOption {
+    return func(c *Client) {
+        c.ClientSecret = clientSecret
+    }
+}
+```
+
+### 3. Similar Issues in Other Service Packages
+
+There are likely similar API mismatches in other service packages that need to be checked and updated.
+
+### 4. HTTP Pool Management
+
+The HTTP pool system (`httppool.GetHTTPClientForService`) may need to be updated to use the new interfaces-based approach.
+
+### 5. Example Files
+
+Many example files may need updates to work with the new API changes.
+
+## Action Plan
+
+1. **Fix Auth Package**:
+   - Create ClientOption functions
+   - Update method signatures
+   - Fix all return values to include error handling
+
+2. **Update Globus.go**:
+   - Update NewAuthClient to use the new Auth API
+   - Add proper error handling
+   - Ensure backwards compatibility where possible
+
+3. **Verify Other Services**:
+   - Check each service for similar issues
+   - Update service packages to use consistent patterns  
+
+4. **Revisit HTTP Pool**:
+   - Ensure HTTP pool management works with new interface-based approach
+   - Update any direct uses of concrete transport types
+
+5. **Fix Examples**:
+   - Update example code to work with the updated API
+   - Ensure examples follow current best practices
+
+## Testing Strategy
+
+1. Fix issues incrementally
+2. Build modules one at a time:
+   - `go build ./pkg/services/auth/...`
+   - `go build ./pkg/...`
+   - `go build ./cmd/...`
+3. Run tests with each change: `go test ./pkg/...`
+4. Once the code builds successfully, re-enable CI workflows
+
+## Next Steps
+
+Once the import cycle and related issues are fully resolved, we should:
+
+1. Update documentation to reflect the new design
+2. Re-enable GitHub Actions workflows
+3. Consider creating a standardized functional options pattern across all service clients
+
+## See Also
+
+- [IMPORT_CYCLE_FIX.md](IMPORT_CYCLE_FIX.md)
+- [IMPORT_CYCLE_RESOLUTION.md](IMPORT_CYCLE_RESOLUTION.md)
+- [GITHUB_ACTIONS_STATUS.md](GITHUB_ACTIONS_STATUS.md)

--- a/pkg/core/transport/transport.go
+++ b/pkg/core/transport/transport.go
@@ -8,22 +8,121 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"time"
 
-	"github.com/scttfrdmn/globus-go-sdk/pkg/core"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/interfaces"
 )
 
 // Transport handles HTTP communication with the API
 type Transport struct {
-	Client *core.Client
+	Client interfaces.ClientInterface
+	Debug  bool
+	Trace  bool
+	Logger *log.Logger
+}
+
+// Options for configuring the transport
+type Options struct {
+	// Debug enables HTTP request/response logging
+	Debug bool
+	
+	// Trace enables detailed HTTP tracing (including bodies)
+	Trace bool
+	
+	// Logger is the logger to use for debug output
+	Logger *log.Logger
 }
 
 // NewTransport creates a new Transport
-func NewTransport(client *core.Client) *Transport {
+func NewTransport(client interfaces.ClientInterface, options *Options) *Transport {
+	// Check environment variables for debug settings
+	envDebug := os.Getenv("GLOBUS_SDK_HTTP_DEBUG") == "1"
+	envTrace := os.Getenv("GLOBUS_SDK_HTTP_TRACE") == "1"
+	
+	debug := envDebug
+	trace := envTrace
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	
+	// Override with options if provided
+	if options != nil {
+		if options.Debug {
+			debug = true
+		}
+		if options.Trace {
+			trace = true
+		}
+		if options.Logger != nil {
+			logger = options.Logger
+		}
+	}
+	
+	// If trace is enabled, debug is also enabled
+	if trace {
+		debug = true
+	}
+	
 	return &Transport{
 		Client: client,
+		Debug:  debug,
+		Trace:  trace,
+		Logger: logger,
+	}
+}
+
+// DeferredTransport holds the transport configuration until a client is available
+type DeferredTransport struct {
+	Debug  bool
+	Trace  bool
+	Logger *log.Logger
+}
+
+// NewDeferredTransport creates a configuration for a transport that can be attached to a client later
+func NewDeferredTransport(options *Options) *DeferredTransport {
+	// Check environment variables for debug settings
+	envDebug := os.Getenv("GLOBUS_SDK_HTTP_DEBUG") == "1"
+	envTrace := os.Getenv("GLOBUS_SDK_HTTP_TRACE") == "1"
+	
+	debug := envDebug
+	trace := envTrace
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	
+	// Override with options if provided
+	if options != nil {
+		if options.Debug {
+			debug = true
+		}
+		if options.Trace {
+			trace = true
+		}
+		if options.Logger != nil {
+			logger = options.Logger
+		}
+	}
+	
+	// If trace is enabled, debug is also enabled
+	if trace {
+		debug = true
+	}
+	
+	return &DeferredTransport{
+		Debug:  debug,
+		Trace:  trace,
+		Logger: logger,
+	}
+}
+
+// AttachClient creates a Transport by attaching a client to a DeferredTransport
+func (dt *DeferredTransport) AttachClient(client interfaces.ClientInterface) *Transport {
+	return &Transport{
+		Client: client,
+		Debug:  dt.Debug,
+		Trace:  dt.Trace,
+		Logger: dt.Logger,
 	}
 }
 
@@ -37,7 +136,7 @@ func (t *Transport) Request(
 	headers http.Header,
 ) (*http.Response, error) {
 	// Build the full URL
-	urlStr := t.Client.BaseURL
+	urlStr := t.Client.GetBaseURL()
 	if !strings.HasSuffix(urlStr, "/") {
 		urlStr += "/"
 	}
@@ -48,9 +147,11 @@ func (t *Transport) Request(
 	}
 
 	// Prepare the request body
+	var bodyBytes []byte
 	var bodyReader io.Reader
 	if body != nil {
-		bodyBytes, err := json.Marshal(body)
+		var err error
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
@@ -82,10 +183,27 @@ func (t *Transport) Request(
 		req.Header.Set("Accept", "application/json")
 	}
 
+	// Log the request if debug is enabled
+	if t.Debug {
+		t.logRequest(method, urlStr, req.Header, bodyBytes)
+	}
+
 	// Send the request
+	startTime := time.Now()
 	resp, err := t.Client.Do(ctx, req)
+	duration := time.Since(startTime)
+
+	// Log the error if there is one
 	if err != nil {
+		if t.Debug {
+			t.Logger.Printf("HTTP Error: %v (%s)", err, duration.Round(time.Millisecond))
+		}
 		return nil, err
+	}
+
+	// Log the response if debug is enabled
+	if t.Debug {
+		t.logResponse(resp, duration)
 	}
 
 	return resp, nil

--- a/pkg/core/transport_init.go
+++ b/pkg/core/transport_init.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package core
+
+import (
+	"log"
+	"os"
+
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/interfaces"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/transport"
+)
+
+// InitTransport initializes a transport for a client
+// This function helps break the import cycle between core and transport packages
+func InitTransport(client interfaces.ClientInterface, debug, trace bool) interfaces.Transport {
+	loggerForTransport := log.New(os.Stderr, "", log.LstdFlags)
+	
+	// Create deferred transport first
+	dt := transport.NewDeferredTransport(&transport.Options{
+		Debug:  debug,
+		Trace:  trace,
+		Logger: loggerForTransport,
+	})
+	
+	// Now attach the client to create the actual transport
+	return dt.AttachClient(client)
+}


### PR DESCRIPTION
## Summary

This PR resolves the import cycle between pkg/core and pkg/core/transport packages that was preventing the codebase from building correctly and causing CI/CD workflows to fail.

## Changes Implemented

1. Created DeferredTransport struct to hold transport configuration without client
2. Added transport_init.go to break dependency cycle
3. Updated Client struct to use Transport interface instead of concrete type
4. Used interface-based design to reduce coupling between packages

## Documentation

- Created IMPORT_CYCLE_FIX.md with detailed explanation of the approach
- Created REMAINING_FIXES.md outlining additional issues to address

## Testing

Core packages build successfully without import cycle errors:


There are still issues in other packages that need to be addressed in follow-up PRs.

## Next Steps

After this PR is merged:
1. Fix the auth client API issues
2. Address similar issues in other service packages
3. Re-enable CI workflows

Resolves import cycle issues mentioned in IMPORT_CYCLE_RESOLUTION.md