### PR TITLE
Fix syntax errors in example applications

### DIFF
--- a/cmd/examples/debugging/main.go
+++ b/cmd/examples/debugging/main.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/authorizers"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/auth"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/transfer"
+)
+
+// customLogger adapts a standard log.Logger to the interfaces.Logger interface
+type customLogger struct {
+	logger *log.Logger
+}
+
+func (l *customLogger) Debug(format string, args ...interface{}) {
+	l.logger.Printf("[DEBUG] "+format, args...)
+}
+
+func (l *customLogger) Info(format string, args ...interface{}) {
+	l.logger.Printf("[INFO] "+format, args...)
+}
+
+func (l *customLogger) Warn(format string, args ...interface{}) {
+	l.logger.Printf("[WARN] "+format, args...)
+}
+
+func (l *customLogger) Error(format string, args ...interface{}) {
+	l.logger.Printf("[ERROR] "+format, args...)
+}
+
+func main() {
+	// Load environment variables from .env.test file
+	_ = godotenv.Load(".env.test")
+
+	// Create a logger to capture debug output
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	// Get credentials
+	clientID := os.Getenv("GLOBUS_TEST_CLIENT_ID")
+	clientSecret := os.Getenv("GLOBUS_TEST_CLIENT_SECRET")
+	sourceEndpointID := os.Getenv("GLOBUS_TEST_SOURCE_ENDPOINT_ID")
+	destEndpointID := os.Getenv("GLOBUS_TEST_DEST_ENDPOINT_ID")
+	
+	if clientID == "" || clientSecret == "" {
+		fmt.Println("ERROR: Missing client credentials. Set GLOBUS_TEST_CLIENT_ID and GLOBUS_TEST_CLIENT_SECRET")
+		os.Exit(1)
+	}
+	
+	if sourceEndpointID == "" || destEndpointID == "" {
+		fmt.Println("ERROR: Missing endpoints. Set GLOBUS_TEST_SOURCE_ENDPOINT_ID and GLOBUS_TEST_DEST_ENDPOINT_ID")
+		os.Exit(1)
+	}
+	
+	// Get token
+	fmt.Println("Getting transfer token...")
+	authClient, err := auth.NewClient(
+		auth.WithClientID(clientID),
+		auth.WithClientSecret(clientSecret),
+	)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create auth client: %v\n", err)
+		os.Exit(1)
+	}
+	
+	tokenResp, err := authClient.GetClientCredentialsToken(context.Background(), transfer.TransferScope)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to get token: %v\n", err)
+		os.Exit(1)
+	}
+	
+	fmt.Printf("Got token with resource server: %s\n", tokenResp.ResourceServer)
+	
+	// Set up auth
+	authorizer := authorizers.StaticTokenCoreAuthorizer(tokenResp.AccessToken)
+
+	// Create a transfer client with debugging enabled
+	clientLogger := &customLogger{logger: logger}
+	client, err := transfer.NewClient(
+		transfer.WithAuthorizer(authorizer),
+		transfer.WithHTTPDebugging(true),
+		transfer.WithHTTPTracing(true), // Enable detailed tracing
+		transfer.WithLogger(clientLogger),
+	)
+	if err != nil {
+		fmt.Printf("Failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Set a timeout context
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	
+	// Create unique test directories
+	timestamp := time.Now().Format("20060102_150405")
+	testDir := fmt.Sprintf("test-debug-%s", timestamp)
+	sourceDir := testDir + "/source"
+	destDir := testDir + "/dest"
+	
+	// Create source directory
+	fmt.Printf("Creating source directory: %s\n", sourceDir)
+	err = client.Mkdir(ctx, sourceEndpointID, sourceDir)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create source directory: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Create destination directory
+	fmt.Printf("Creating destination directory: %s\n", destDir)
+	err = client.Mkdir(ctx, destEndpointID, destDir)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create destination directory: %v\n", err)
+		// Still continue
+	}
+	
+	// Test JSON serialization
+	fmt.Println("\nTesting JSON serialization for TransferTaskRequest")
+	
+	// Create transfer request with uppercase and lowercase JSON data fields
+	transferRequestLower := &transfer.TransferTaskRequest{
+		DataType:              "transfer",
+		Label:                 fmt.Sprintf("Debug Lower Test %s", timestamp),
+		SourceEndpointID:      sourceEndpointID,
+		DestinationEndpointID: destEndpointID,
+		Encrypt:               true,
+		VerifyChecksum:        true,
+		Items: []transfer.TransferItem{
+			{
+				SourcePath:      sourceDir,
+				DestinationPath: destDir,
+				Recursive:       true,
+			},
+		},
+	}
+	
+	// Print JSON requests
+	jsonLower, _ := json.MarshalIndent(transferRequestLower, "", "  ")
+	fmt.Printf("Lower case JSON 'data': %s\n\n", string(jsonLower))
+	
+	// Submit transfer with proper case
+	fmt.Println("Submitting transfer task...")
+	resp, err := client.CreateTransferTask(ctx, transferRequestLower)
+	if err != nil {
+		fmt.Printf("ERROR: Transfer task failed: %v\n", err)
+	} else {
+		fmt.Printf("Transfer task submitted successfully. Task ID: %s\n", resp.TaskID)
+	}
+	
+	// Clean up
+	fmt.Println("Cleaning up test directories...")
+	
+	// Create delete tasks to clean up the directories
+	sourceDeleteRequest := &transfer.DeleteTaskRequest{
+		DataType:     "delete",
+		Label:        "Cleanup Debug Test Directory - Source",
+		EndpointID:   sourceEndpointID,
+		Items: []transfer.DeleteItem{
+			{
+				Path:     testDir,
+				DataType: "delete_item",
+			},
+		},
+	}
+	
+	destDeleteRequest := &transfer.DeleteTaskRequest{
+		DataType:     "delete",
+		Label:        "Cleanup Debug Test Directory - Destination",
+		EndpointID:   destEndpointID,
+		Items: []transfer.DeleteItem{
+			{
+				Path:     testDir,
+				DataType: "delete_item",
+			},
+		},
+	}
+	
+	// Submit delete tasks - ignore errors as these are just cleanup operations
+	_, _ = client.CreateDeleteTask(ctx, sourceDeleteRequest)
+	_, _ = client.CreateDeleteTask(ctx, destDeleteRequest)
+	
+	fmt.Println("Done.")
+}

--- a/cmd/examples/flows/main.go
+++ b/cmd/examples/flows/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/scttfrdmn/globus-go-sdk/pkg"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/flows"
 )
 
 func main() {
@@ -20,7 +21,10 @@ func main() {
 		WithClientSecret(os.Getenv("GLOBUS_CLIENT_SECRET"))
 
 	// Create a new Auth client
-	authClient := config.NewAuthClient()
+	authClient, err := config.NewAuthClient()
+	if err != nil {
+		log.Fatalf("Failed to create auth client: %v", err)
+	}
 
 	// Get token using client credentials for simplicity
 	// In a real application, you would likely use the authorization code flow
@@ -30,8 +34,7 @@ func main() {
 		log.Fatalf("Failed to get token: %v", err)
 	}
 
-	fmt.Printf("Obtained access token (expires in %d seconds)
-", tokenResp.ExpiresIn)
+	fmt.Printf("Obtained access token (expires in %d seconds)\n", tokenResp.ExpiresIn)
 	accessToken := tokenResp.AccessToken
 
 	// Create Flows client
@@ -41,22 +44,20 @@ func main() {
 	flowID := os.Getenv("GLOBUS_FLOW_ID")
 	if flowID == "" {
 		// List available flows if no flow ID is provided
-		fmt.Println("
-=== Available Flows ===")
+		fmt.Println("\n=== Available Flows ===")
 		
-		flows, err := flowsClient.ListFlows(ctx, &pkg.ListFlowsOptions{
+		flowsList, err := flowsClient.ListFlows(ctx, &flows.ListFlowsOptions{
 			Limit: 5,
 		})
 		if err != nil {
 			log.Fatalf("Failed to list flows: %v", err)
 		}
 		
-		if len(flows.Flows) == 0 {
+		if len(flowsList.Flows) == 0 {
 			fmt.Println("No flows found. Create a flow first.")
 			
 			// Create a simple flow for demonstration
-			fmt.Println("
-=== Creating New Flow ===")
+			fmt.Println("\n=== Creating New Flow ===")
 			
 			timestamp := time.Now().Format("20060102_150405")
 			flowTitle := fmt.Sprintf("SDK Example Flow %s", timestamp)
@@ -89,7 +90,7 @@ func main() {
 				},
 			}
 			
-			createRequest := &pkg.FlowCreateRequest{
+			createRequest := &flows.FlowCreateRequest{
 				Title:       flowTitle,
 				Description: "An example flow created by the Globus Go SDK",
 				Definition:  flowDefinition,
@@ -100,22 +101,17 @@ func main() {
 				log.Fatalf("Failed to create flow: %v", err)
 			}
 			
-			fmt.Printf("Created new flow: %s (%s)
-", newFlow.Title, newFlow.ID)
+			fmt.Printf("Created new flow: %s (%s)\n", newFlow.Title, newFlow.ID)
 			flowID = newFlow.ID
 		} else {
 			// Use the first available flow
-			fmt.Printf("Found %d flows:
-", len(flows.Flows))
-			for i, flow := range flows.Flows {
-				fmt.Printf("%d. %s (%s)
-", i+1, flow.Title, flow.ID)
+			fmt.Printf("Found %d flows:\n", len(flowsList.Flows))
+			for i, flow := range flowsList.Flows {
+				fmt.Printf("%d. %s (%s)\n", i+1, flow.Title, flow.ID)
 			}
 			
-			flowID = flows.Flows[0].ID
-			fmt.Printf("
-Using first flow: %s
-", flowID)
+			flowID = flowsList.Flows[0].ID
+			fmt.Printf("\nUsing first flow: %s\n", flowID)
 		}
 	}
 
@@ -125,37 +121,25 @@ Using first flow: %s
 		log.Fatalf("Failed to get flow: %v", err)
 	}
 	
-	fmt.Printf("
-=== Flow Details ===
-")
-	fmt.Printf("ID: %s
-", flow.ID)
-	fmt.Printf("Title: %s
-", flow.Title)
-	fmt.Printf("Description: %s
-", flow.Description)
-	fmt.Printf("Owner: %s
-", flow.FlowOwner)
-	fmt.Printf("Created: %s
-", flow.CreatedAt.Format(time.RFC3339))
-	fmt.Printf("Run Count: %d
-", flow.RunCount)
+	fmt.Printf("\n=== Flow Details ===\n")
+	fmt.Printf("ID: %s\n", flow.ID)
+	fmt.Printf("Title: %s\n", flow.Title)
+	fmt.Printf("Description: %s\n", flow.Description)
+	fmt.Printf("Owner: %s\n", flow.FlowOwner)
+	fmt.Printf("Created: %s\n", flow.CreatedAt.Format(time.RFC3339))
+	fmt.Printf("Run Count: %d\n", flow.RunCount)
 	
 	// Print input schema if available
 	if flow.InputSchema != nil {
 		inputSchemaJSON, _ := json.MarshalIndent(flow.InputSchema, "", "  ")
-		fmt.Printf("
-Input Schema:
-%s
-", inputSchemaJSON)
+		fmt.Printf("\nInput Schema:\n%s\n", inputSchemaJSON)
 	}
 
 	// Run the flow
-	fmt.Println("
-=== Running Flow ===")
+	fmt.Println("\n=== Running Flow ===")
 	
 	// Create a run request
-	runRequest := &pkg.RunRequest{
+	runRequest := &flows.RunRequest{
 		FlowID: flowID,
 		Label:  "SDK Example Run " + time.Now().Format("20060102_150405"),
 		Tags:   []string{"example", "sdk", "go"},
@@ -169,16 +153,12 @@ Input Schema:
 		log.Fatalf("Failed to run flow: %v", err)
 	}
 	
-	fmt.Printf("Flow run started with ID: %s
-", run.RunID)
-	fmt.Printf("Status: %s
-", run.Status)
-	fmt.Printf("Created at: %s
-", run.CreatedAt.Format(time.RFC3339))
+	fmt.Printf("Flow run started with ID: %s\n", run.RunID)
+	fmt.Printf("Status: %s\n", run.Status)
+	fmt.Printf("Created at: %s\n", run.CreatedAt.Format(time.RFC3339))
 	
 	// Wait for a few seconds to let the flow run
-	fmt.Println("
-Waiting for flow run to complete...")
+	fmt.Println("\nWaiting for flow run to complete...")
 	time.Sleep(3 * time.Second)
 	
 	// Get updated run status
@@ -187,27 +167,19 @@ Waiting for flow run to complete...")
 		log.Fatalf("Failed to get run status: %v", err)
 	}
 	
-	fmt.Printf("
-=== Run Status ===
-")
-	fmt.Printf("Status: %s
-", runStatus.Status)
+	fmt.Printf("\n=== Run Status ===\n")
+	fmt.Printf("Status: %s\n", runStatus.Status)
 	if runStatus.CompletedAt.IsZero() {
 		fmt.Println("Run is still in progress")
 	} else {
-		fmt.Printf("Completed at: %s
-", runStatus.CompletedAt.Format(time.RFC3339))
-		fmt.Printf("Duration: %s
-", runStatus.CompletedAt.Sub(runStatus.CreatedAt))
+		fmt.Printf("Completed at: %s\n", runStatus.CompletedAt.Format(time.RFC3339))
+		fmt.Printf("Duration: %s\n", runStatus.CompletedAt.Sub(runStatus.CreatedAt))
 	}
 	
 	// Show run output if available
 	if runStatus.Output != nil {
 		outputJSON, _ := json.MarshalIndent(runStatus.Output, "", "  ")
-		fmt.Printf("
-Run Output:
-%s
-", outputJSON)
+		fmt.Printf("\nRun Output:\n%s\n", outputJSON)
 	}
 	
 	// Get run logs
@@ -215,12 +187,9 @@ Run Output:
 	if err != nil {
 		log.Printf("Failed to get run logs: %v", err)
 	} else {
-		fmt.Printf("
-=== Run Logs (%d entries) ===
-", len(logs.Entries))
+		fmt.Printf("\n=== Run Logs (%d entries) ===\n", len(logs.Entries))
 		for i, entry := range logs.Entries {
-			fmt.Printf("%d. [%s] %s - %s
-", 
+			fmt.Printf("%d. [%s] %s - %s\n", 
 				i+1, 
 				entry.CreatedAt.Format("15:04:05"),
 				entry.Code, 
@@ -228,27 +197,23 @@ Run Output:
 			
 			if entry.Details != nil && len(entry.Details) > 0 {
 				detailsJSON, _ := json.MarshalIndent(entry.Details, "", "  ")
-				fmt.Printf("   Details: %s
-", detailsJSON)
+				fmt.Printf("   Details: %s\n", detailsJSON)
 			}
 		}
 	}
 	
 	// List action providers
-	fmt.Println("
-=== Action Providers ===")
-	providers, err := flowsClient.ListActionProviders(ctx, &pkg.ListActionProvidersOptions{
+	fmt.Println("\n=== Action Providers ===")
+	providers, err := flowsClient.ListActionProviders(ctx, &flows.ListActionProvidersOptions{
 		Limit:        5,
 		FilterGlobus: true,
 	})
 	if err != nil {
 		log.Printf("Failed to list action providers: %v", err)
 	} else {
-		fmt.Printf("Found %d Globus action providers:
-", len(providers.ActionProviders))
+		fmt.Printf("Found %d Globus action providers:\n", len(providers.ActionProviders))
 		for i, provider := range providers.ActionProviders {
-			fmt.Printf("%d. %s (%s) - %s
-", 
+			fmt.Printf("%d. %s (%s) - %s\n", 
 				i+1, 
 				provider.DisplayName, 
 				provider.ID,
@@ -258,26 +223,21 @@ Run Output:
 		// Show roles for the first provider
 		if len(providers.ActionProviders) > 0 {
 			provider := providers.ActionProviders[0]
-			fmt.Printf("
-Roles for %s:
-", provider.DisplayName)
+			fmt.Printf("\nRoles for %s:\n", provider.DisplayName)
 			
 			roles, err := flowsClient.ListActionRoles(ctx, provider.ID, 5, 0)
 			if err != nil {
 				log.Printf("Failed to list action roles: %v", err)
 			} else {
 				for i, role := range roles.ActionRoles {
-					fmt.Printf("%d. %s (%s)
-", i+1, role.Name, role.ID)
+					fmt.Printf("%d. %s (%s)\n", i+1, role.Name, role.ID)
 					if role.Description != "" {
-						fmt.Printf("   Description: %s
-", role.Description)
+						fmt.Printf("   Description: %s\n", role.Description)
 					}
 				}
 			}
 		}
 	}
 
-	fmt.Println("
-Flows example complete!")
+	fmt.Println("\nFlows example complete!")
 }

--- a/cmd/examples/transfer/main.go
+++ b/cmd/examples/transfer/main.go
@@ -46,18 +46,15 @@ func main() {
 	}
 
 	// Print endpoints
-	fmt.Printf("Found %d endpoints:
-", len(endpoints.Data))
+	fmt.Printf("Found %d endpoints:\n", len(endpoints.Data))
 	for i, ep := range endpoints.Data {
-		fmt.Printf("%d. %s (%s) - %s
-", i+1, ep.DisplayName, ep.ID, 
+		fmt.Printf("%d. %s (%s) - %s\n", i+1, ep.DisplayName, ep.ID, 
 			map[bool]string{true: "Activated", false: "Not Activated"}[ep.Activated])
 	}
 
 	// Ask user to select source and destination endpoints
 	var sourceIdx, destIdx int
-	fmt.Print("
-Select source endpoint (enter number): ")
+	fmt.Print("\nSelect source endpoint (enter number): ")
 	fmt.Scanln(&sourceIdx)
 	sourceIdx-- // Adjust for 0-based indexing
 
@@ -94,9 +91,9 @@ Select source endpoint (enter number): ")
 	// Submit transfer
 	fmt.Println("Submitting transfer task...")
 	options2 := map[string]interface{}{
-		"recursive":      true,
+		"recursive":       true,
 		"verify_checksum": true,
-		"preserve_mtime": true,
+		"preserve_mtime":  true,
 	}
 
 	taskResponse, err := transferClient.SubmitTransfer(
@@ -111,7 +108,6 @@ Select source endpoint (enter number): ")
 		log.Fatalf("Failed to submit transfer: %v", err)
 	}
 
-	fmt.Printf("Transfer submitted! Task ID: %s
-", taskResponse.TaskID)
+	fmt.Printf("Transfer submitted! Task ID: %s\n", taskResponse.TaskID)
 	fmt.Println("You can monitor this transfer task in the Globus web interface.")
 }

--- a/debug/debug_delete.go
+++ b/debug/debug_delete.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/auth"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/transfer"
+)
+
+// testAuthorizer implements the authorizer interface for testing
+type testAuthorizer struct {
+	token string
+}
+
+// GetAuthorizationHeader returns the authorization header value
+func (a *testAuthorizer) GetAuthorizationHeader(ctx ...context.Context) (string, error) {
+	return "Bearer " + a.token, nil
+}
+
+// IsValid returns whether the authorization is valid
+func (a *testAuthorizer) IsValid() bool {
+	return a.token != ""
+}
+
+// GetToken returns the token
+func (a *testAuthorizer) GetToken() string {
+	return a.token
+}
+
+func getTestCredentials() (string, string, string, string) {
+	clientID := os.Getenv("GLOBUS_TEST_CLIENT_ID")
+	clientSecret := os.Getenv("GLOBUS_TEST_CLIENT_SECRET")
+	sourceEndpointID := os.Getenv("GLOBUS_TEST_SOURCE_ENDPOINT_ID")
+	destEndpointID := os.Getenv("GLOBUS_TEST_DEST_ENDPOINT_ID")
+
+	if clientID == "" {
+		fmt.Println("GLOBUS_TEST_CLIENT_ID environment variable not set")
+		os.Exit(1)
+	}
+	
+	if clientSecret == "" {
+		fmt.Println("GLOBUS_TEST_CLIENT_SECRET environment variable not set")
+		os.Exit(1)
+	}
+
+	return clientID, clientSecret, sourceEndpointID, destEndpointID
+}
+
+func getAccessToken(clientID, clientSecret string) string {
+	// First, check if there's a transfer token provided directly
+	staticToken := os.Getenv("GLOBUS_TEST_TRANSFER_TOKEN")
+	if staticToken != "" {
+		fmt.Println("Using static transfer token from environment")
+		return staticToken
+	}
+	
+	// If no static token, try to get one via client credentials
+	fmt.Println("Getting client credentials token for transfer")
+	authClient, err := auth.NewClient(
+		auth.WithClientID(clientID),
+		auth.WithClientSecret(clientSecret),
+	)
+	if err != nil {
+		fmt.Printf("Failed to create auth client: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Try different scopes that might work for transfer
+	scopes := []string{
+		"urn:globus:auth:scope:transfer.api.globus.org:all",
+		"https://auth.globus.org/scopes/transfer.api.globus.org/all",
+	}
+	
+	var tokenResp *auth.TokenResponse
+	var err error
+	var gotToken bool
+	
+	// Try each scope until we get a token
+	for _, scope := range scopes {
+		tokenResp, err = authClient.GetClientCredentialsToken(context.Background(), scope)
+		if err != nil {
+			fmt.Printf("Failed to get token with scope %s: %v\n", scope, err)
+			continue
+		}
+		
+		// Check if we got a token for the transfer service
+		fmt.Printf("Got token with resource server: %s, scopes: %s\n", tokenResp.ResourceServer, tokenResp.Scope)
+		if tokenResp.ResourceServer != "" && (
+		   tokenResp.ResourceServer == "transfer.api.globus.org" || 
+		   tokenResp.Scope == "urn:globus:auth:scope:transfer.api.globus.org:all") {
+			gotToken = true
+			break
+		}
+	}
+	
+	// If we didn't get a transfer token, fall back to the default token
+	if !gotToken {
+		fmt.Println("Could not get a transfer token, falling back to default token")
+		tokenResp, err = authClient.GetClientCredentialsToken(context.Background())
+		if err != nil {
+			fmt.Printf("Failed to get any token: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Using default token with resource server: %s, scopes: %s\n", 
+		       tokenResp.ResourceServer, tokenResp.Scope)
+		fmt.Println("WARNING: This token may not have transfer permissions. Consider providing GLOBUS_TEST_TRANSFER_TOKEN")
+	}
+	
+	return tokenResp.AccessToken
+}
+
+func main() {
+	// Load environment variables
+	_ = godotenv.Load(".env.test")
+	_ = godotenv.Load("pkg/.env.test")
+	_ = godotenv.Load("pkg/services/.env.test")
+	_ = godotenv.Load("pkg/services/transfer/.env.test")
+	
+	// Enable debug output
+	os.Setenv("HTTP_DEBUG", "1")
+	
+	// Get credentials
+	clientID, clientSecret, sourceEndpointID, _ := getTestCredentials()
+	if sourceEndpointID == "" {
+		fmt.Println("GLOBUS_TEST_SOURCE_ENDPOINT_ID environment variable not set")
+		os.Exit(1)
+	}
+
+	// Get access token
+	accessToken := getAccessToken(clientID, clientSecret)
+	
+	// Create transfer client with debugging enabled
+	client, err := transfer.NewClient(
+		transfer.WithAuthorizer(&testAuthorizer{token: accessToken}),
+		transfer.WithHTTPDebugging(true),
+		transfer.WithHTTPTracing(true),
+	)
+	if err != nil {
+		fmt.Printf("Failed to create transfer client: %v\n", err)
+		os.Exit(1)
+	}
+	
+	ctx := context.Background()
+	
+	// Create a test directory to delete
+	testBasePath := os.Getenv("GLOBUS_TEST_DIRECTORY_PATH")
+	if testBasePath == "" {
+		testBasePath = "globus-test" // Default to a simple test directory 
+	}
+	
+	timestamp := time.Now().Format("20060102_150405")
+	testDir := fmt.Sprintf("%s/debug_delete_test_%s", testBasePath, timestamp)
+	
+	// Try to create the directory first
+	fmt.Printf("Creating test directory: %s\n", testDir)
+	err = client.Mkdir(ctx, sourceEndpointID, testDir)
+	if err != nil {
+		fmt.Printf("Failed to create test directory: %v\n", err)
+		os.Exit(1)
+	}
+	
+	fmt.Println("Test directory created successfully")
+	
+	// Now try to delete the directory - showing the request structure
+	fmt.Println("\nAttempting to delete the directory...")
+	
+	// Get a submission ID manually to see if it's working
+	subID, err := client.GetSubmissionID(ctx)
+	if err != nil {
+		fmt.Printf("Failed to get submission ID: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Got submission ID: %s\n", subID)
+	
+	// First try with current implementation
+	deleteRequest := &transfer.DeleteTaskRequest{
+		DataType:     "delete",
+		Label:        fmt.Sprintf("Debug delete test %s", timestamp),
+		EndpointID:   sourceEndpointID,
+		SubmissionID: subID,
+		Items: []transfer.DeleteItem{
+			{
+				Path:      testDir,
+				Recursive: true,
+			},
+		},
+	}
+	
+	fmt.Println("\nAttempting delete with current implementation (Items under DATA)...")
+	deleteResp, err := client.CreateDeleteTask(ctx, deleteRequest)
+	if err != nil {
+		fmt.Printf("Delete task failed: %v\n", err)
+		// Continue with modified version
+	} else {
+		fmt.Printf("Delete task successful: %s\n", deleteResp.TaskID)
+		fmt.Println("No fix needed! The current implementation works.")
+		os.Exit(0)
+	}
+	
+	// If we're here, the standard implementation failed
+	// Skip manual construction and go directly to testing our fixed implementation
+	fmt.Println("\nStandard implementation failed, trying with our fixed implementation...")
+
+	// We can't use the base client directly, so manually create a new delete task request with the proper format
+	fmt.Println("\nSkipping modified request test - using the standard client with the modified structure")
+	
+	// Instead, let's create another test directory and try again with our updated DeleteTaskRequest structure
+	testDir2 := fmt.Sprintf("%s/debug_delete_test2_%s", testBasePath, timestamp)
+	fmt.Printf("\nCreating a second test directory: %s\n", testDir2)
+	
+	err = client.Mkdir(ctx, sourceEndpointID, testDir2)
+	if err != nil {
+		fmt.Printf("Failed to create second test directory: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Get a new submission ID
+	subID2, err := client.GetSubmissionID(ctx)
+	if err != nil {
+		fmt.Printf("Failed to get second submission ID: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Try with our modified implementation
+	deleteRequest2 := &transfer.DeleteTaskRequest{
+		DataType:     "delete",
+		Label:        fmt.Sprintf("Debug delete test 2 %s", timestamp),
+		EndpointID:   sourceEndpointID,
+		SubmissionID: subID2,
+		Items: []transfer.DeleteItem{
+			{
+				DataType:  "delete_item",
+				Path:      testDir2,
+				Recursive: true,
+			},
+		},
+	}
+	
+	fmt.Println("\nAttempting delete with updated implementation and DataType fields added...")
+	deleteResp2, err := client.CreateDeleteTask(ctx, deleteRequest2)
+	if err != nil {
+		fmt.Printf("Delete task still failed: %v\n", err)
+		fmt.Println("\nMore debugging may be required to resolve this issue")
+	} else {
+		fmt.Printf("Success! Delete task successful with updated implementation: %s\n", deleteResp2.TaskID)
+		fmt.Println("\nFIX IS WORKING: The structure changes worked!")
+	}
+}

--- a/debug/debug_delete_comprehensive.go
+++ b/debug/debug_delete_comprehensive.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/transfer"
+)
+
+// testAuthorizer implements the authorizer interface for testing
+type testAuthorizer struct {
+	token string
+}
+
+// GetAuthorizationHeader returns the authorization header value
+func (a *testAuthorizer) GetAuthorizationHeader(ctx ...context.Context) (string, error) {
+	return "Bearer " + a.token, nil
+}
+
+// IsValid returns whether the authorization is valid
+func (a *testAuthorizer) IsValid() bool {
+	return a.token != ""
+}
+
+// GetToken returns the token
+func (a *testAuthorizer) GetToken() string {
+	return a.token
+}
+
+// EnhancedDeleteItem adds a DATA_TYPE field to DeleteItem
+type EnhancedDeleteItem struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive,omitempty"`
+	DataType  string `json:"DATA_TYPE,omitempty"`
+}
+
+// EnhancedDeleteTaskRequest adds DATA_TYPE field to DeleteItem
+type EnhancedDeleteTaskRequest struct {
+	DataType          string               `json:"DATA_TYPE,omitempty"`
+	Label             string               `json:"label,omitempty"`
+	EndpointID        string               `json:"endpoint"`
+	Deadline          *time.Time           `json:"deadline,omitempty"`
+	NotifyOnSucceeded bool                 `json:"notify_on_succeeded,omitempty"`
+	NotifyOnFailed    bool                 `json:"notify_on_failed,omitempty"`
+	NotifyOnInactive  bool                 `json:"notify_on_inactive,omitempty"`
+	SubmissionID      string               `json:"submission_id,omitempty"`
+	Items             []EnhancedDeleteItem `json:"DATA"`
+}
+
+func main() {
+	// Load environment variables
+	_ = godotenv.Load(".env.test")
+
+	// Get credentials from environment
+	accessToken := os.Getenv("GLOBUS_TEST_TRANSFER_TOKEN")
+	if accessToken == "" {
+		fmt.Println("ERROR: GLOBUS_TEST_TRANSFER_TOKEN environment variable is required")
+		os.Exit(1)
+	}
+
+	endpointID := os.Getenv("GLOBUS_TEST_SOURCE_ENDPOINT_ID")
+	if endpointID == "" {
+		fmt.Println("ERROR: GLOBUS_TEST_SOURCE_ENDPOINT_ID environment variable is required")
+		os.Exit(1)
+	}
+
+	// Enable HTTP debugging
+	os.Setenv("HTTP_DEBUG", "true")
+
+	// Create Transfer client with debugging enabled
+	client, err := transfer.NewClient(
+		transfer.WithAuthorizer(&testAuthorizer{token: accessToken}),
+		transfer.WithHTTPDebugging(true),
+	)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create transfer client: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	timestamp := time.Now().Format("20060102_150405")
+
+	// Create test directories for our two tests
+	testPath1 := fmt.Sprintf("globus-test/debug_original_%s", timestamp)
+	testPath2 := fmt.Sprintf("globus-test/debug_enhanced_%s", timestamp)
+
+	// Create the first test directory
+	fmt.Printf("Creating test directory 1: %s\n", testPath1)
+	err = client.Mkdir(ctx, endpointID, testPath1)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create test directory 1: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the second test directory
+	fmt.Printf("Creating test directory 2: %s\n", testPath2)
+	err = client.Mkdir(ctx, endpointID, testPath2)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create test directory 2: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Get submission ID for our requests
+	submissionID, err := client.GetSubmissionID(ctx)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to get submission ID: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Test 1: Original implementation
+	fmt.Println("\n=== TEST 1: ORIGINAL IMPLEMENTATION ===")
+	fmt.Println("Using the current SDK implementation without DATA_TYPE field in delete items")
+
+	deleteRequest1 := &transfer.DeleteTaskRequest{
+		DataType:     "delete",
+		Label:        "Debug original implementation",
+		EndpointID:   endpointID,
+		SubmissionID: submissionID,
+		Items: []transfer.DeleteItem{
+			{
+				Path:      testPath1,
+				Recursive: true,
+			},
+		},
+	}
+
+	// Print the JSON that will be sent
+	reqJSON1, _ := json.MarshalIndent(deleteRequest1, "", "  ")
+	fmt.Printf("Request JSON:\n%s\n\n", string(reqJSON1))
+
+	// Try to create the delete task
+	fmt.Println("Sending delete request with SDK...")
+	resp1, err := client.CreateDeleteTask(ctx, deleteRequest1)
+	
+	if err != nil {
+		fmt.Printf("ERROR: Original delete task failed: %v\n", err)
+	} else {
+		fmt.Printf("SUCCESS: Original delete task created with task ID: %s\n", resp1.TaskID)
+	}
+
+	// Test 2: Enhanced implementation with DATA_TYPE field
+	fmt.Println("\n=== TEST 2: ENHANCED IMPLEMENTATION ===")
+	fmt.Println("Adding DATA_TYPE field to each delete item")
+
+	// Create an enhanced request with DATA_TYPE field for each item
+	enhancedRequest := EnhancedDeleteTaskRequest{
+		DataType:     "delete",
+		Label:        "Debug with DATA_TYPE for items",
+		EndpointID:   endpointID,
+		SubmissionID: submissionID,
+		Items: []EnhancedDeleteItem{
+			{
+				Path:      testPath2,
+				Recursive: true,
+				DataType:  "delete_item", // This is the key difference
+			},
+		},
+	}
+
+	// Print the enhanced JSON
+	reqJSON2, _ := json.MarshalIndent(enhancedRequest, "", "  ")
+	fmt.Printf("Enhanced Request JSON:\n%s\n\n", string(reqJSON2))
+
+	// We can't use the SDK directly with our enhanced struct, so we'll send the request manually
+	reqBody, err := json.Marshal(enhancedRequest)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to marshal enhanced request: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create an HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, 
+		"https://transfer.api.globus.org/v0.10/delete", bytes.NewReader(reqBody))
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create HTTP request: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	// Send the request
+	fmt.Println("Sending enhanced delete request directly...")
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		fmt.Printf("ERROR: HTTP request failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	// Read and parse the response
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to read response: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print response status and body
+	fmt.Printf("Response status: %s\n", resp.Status)
+	fmt.Printf("Response body: %s\n", string(respBody))
+
+	// Parse the response
+	var taskResp transfer.TaskResponse
+	if err := json.Unmarshal(respBody, &taskResp); err != nil {
+		fmt.Printf("ERROR: Failed to parse response: %v\n", err)
+	} else if taskResp.TaskID != "" {
+		fmt.Printf("SUCCESS: Enhanced delete task created with task ID: %s\n", taskResp.TaskID)
+	}
+
+	fmt.Println("\n=== DEBUGGING COMPLETE ===")
+	fmt.Println("If the enhanced implementation succeeded but the original failed,")
+	fmt.Println("then adding the DATA_TYPE field to delete items is likely the solution.")
+	fmt.Println("This would require updating the DeleteItem struct in models.go to include DataType")
+	fmt.Println("and modifying CreateDeleteTask to set it to \"delete_item\" for each item.")
+}

--- a/debug/debug_delete_minimal.go
+++ b/debug/debug_delete_minimal.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/auth"
+)
+
+func getAccessToken(clientID, clientSecret string) string {
+	// First, check if there's a transfer token provided directly
+	staticToken := os.Getenv("GLOBUS_TEST_TRANSFER_TOKEN")
+	if staticToken != "" {
+		fmt.Println("Using static transfer token from environment")
+		return staticToken
+	}
+	
+	// If no static token, try to get one via client credentials
+	fmt.Println("Getting client credentials token for transfer")
+	authClient, err := auth.NewClient(
+		auth.WithClientID(clientID),
+		auth.WithClientSecret(clientSecret),
+	)
+	if err != nil {
+		fmt.Printf("Failed to create auth client: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Try different scopes that might work for transfer
+	scopes := []string{
+		"urn:globus:auth:scope:transfer.api.globus.org:all",
+		"https://auth.globus.org/scopes/transfer.api.globus.org/all",
+	}
+	
+	var tokenResp *auth.TokenResponse
+	var err error
+	var gotToken bool
+	
+	// Try each scope until we get a token
+	for _, scope := range scopes {
+		tokenResp, err = authClient.GetClientCredentialsToken(context.Background(), scope)
+		if err != nil {
+			fmt.Printf("Failed to get token with scope %s: %v\n", scope, err)
+			continue
+		}
+		
+		// Check if we got a token for the transfer service
+		fmt.Printf("Got token with resource server: %s, scopes: %s\n", tokenResp.ResourceServer, tokenResp.Scope)
+		if tokenResp.ResourceServer != "" && (
+		   tokenResp.ResourceServer == "transfer.api.globus.org" || 
+		   tokenResp.Scope == "urn:globus:auth:scope:transfer.api.globus.org:all") {
+			gotToken = true
+			break
+		}
+	}
+	
+	// If we didn't get a transfer token, fall back to the default token
+	if !gotToken {
+		fmt.Println("Could not get a transfer token, falling back to default token")
+		tokenResp, err = authClient.GetClientCredentialsToken(context.Background())
+		if err != nil {
+			fmt.Printf("Failed to get any token: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	
+	return tokenResp.AccessToken
+}
+
+func main() {
+	// Load environment variables
+	_ = godotenv.Load(".env.test")
+	_ = godotenv.Load("pkg/.env.test")
+	
+	// Enable debug output
+	os.Setenv("HTTP_DEBUG", "1")
+	
+	// Get credentials
+	clientID := os.Getenv("GLOBUS_TEST_CLIENT_ID")
+	clientSecret := os.Getenv("GLOBUS_TEST_CLIENT_SECRET")
+	sourceEndpointID := os.Getenv("GLOBUS_TEST_SOURCE_ENDPOINT_ID")
+	
+	if clientID == "" || clientSecret == "" || sourceEndpointID == "" {
+		fmt.Println("Required environment variables not set")
+		os.Exit(1)
+	}
+
+	// Get access token
+	accessToken := getAccessToken(clientID, clientSecret)
+	
+	// Create a test directory to delete (raw HTTP request)
+	testBasePath := os.Getenv("GLOBUS_TEST_DIRECTORY_PATH")
+	if testBasePath == "" {
+		testBasePath = "globus-test" // Default to a simple test directory 
+	}
+	
+	timestamp := time.Now().Format("20060102_150405")
+	testDir := fmt.Sprintf("%s/debug_delete_minimal_%s", testBasePath, timestamp)
+	
+	// Create directory with raw HTTP request
+	createDirBody := map[string]string{
+		"path":      testDir,
+		"DATA_TYPE": "mkdir",
+	}
+	createDirBodyJSON, _ := json.Marshal(createDirBody)
+	
+	// Build the request
+	createDirReq, _ := http.NewRequest(
+		"POST",
+		fmt.Sprintf("https://transfer.api.globus.org/v0.10/operation/endpoint/%s/mkdir", sourceEndpointID),
+		bytes.NewReader(createDirBodyJSON),
+	)
+	createDirReq.Header.Set("Authorization", "Bearer "+accessToken)
+	createDirReq.Header.Set("Content-Type", "application/json")
+	
+	// Send the request
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(createDirReq)
+	if err != nil {
+		fmt.Printf("Failed to create directory: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	
+	// Print response
+	respBody, _ := io.ReadAll(resp.Body)
+	fmt.Printf("Create directory status: %d\n", resp.StatusCode)
+	fmt.Printf("Create directory response: %s\n", string(respBody))
+	
+	if resp.StatusCode >= 400 {
+		fmt.Println("Failed to create directory")
+		os.Exit(1)
+	}
+	
+	// Get a submission ID
+	submissionIDReq, _ := http.NewRequest(
+		"GET",
+		"https://transfer.api.globus.org/v0.10/submission_id",
+		nil,
+	)
+	submissionIDReq.Header.Set("Authorization", "Bearer "+accessToken)
+	submissionIDReq.Header.Set("Accept", "application/json")
+	
+	resp, err = client.Do(submissionIDReq)
+	if err != nil {
+		fmt.Printf("Failed to get submission ID: %v\n", err)
+		os.Exit(1)
+	}
+	
+	var submissionIDResp struct {
+		Value string `json:"value"`
+	}
+	respBody, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	
+	fmt.Printf("Submission ID status: %d\n", resp.StatusCode)
+	fmt.Printf("Submission ID response: %s\n", string(respBody))
+	
+	if err := json.Unmarshal(respBody, &submissionIDResp); err != nil {
+		fmt.Printf("Failed to parse submission ID: %v\n", err)
+		os.Exit(1)
+	}
+	
+	submissionID := submissionIDResp.Value
+	fmt.Printf("Got submission ID: %s\n", submissionID)
+	
+	// Try delete with a completely custom JSON payload
+	// This is a minimal request based on the API docs
+	deleteReqBody := fmt.Sprintf(`{
+		"DATA_TYPE": "delete",
+		"submission_id": "%s",
+		"endpoint": "%s",
+		"label": "SDK Delete Test %s",
+		"DATA": [
+			{
+				"DATA_TYPE": "delete_item",
+				"path": "%s"
+			}
+		]
+	}`, submissionID, sourceEndpointID, timestamp, testDir)
+	
+	fmt.Printf("Delete request body: %s\n", deleteReqBody)
+	
+	deleteReq, _ := http.NewRequest(
+		"POST",
+		"https://transfer.api.globus.org/v0.10/delete",
+		bytes.NewReader([]byte(deleteReqBody)),
+	)
+	deleteReq.Header.Set("Authorization", "Bearer "+accessToken)
+	deleteReq.Header.Set("Content-Type", "application/json")
+	deleteReq.Header.Set("Accept", "application/json")
+	
+	resp, err = client.Do(deleteReq)
+	if err != nil {
+		fmt.Printf("Failed to send delete request: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	
+	respBody, _ = io.ReadAll(resp.Body)
+	fmt.Printf("Delete task status: %d\n", resp.StatusCode)
+	fmt.Printf("Delete task response: %s\n", string(respBody))
+	
+	if resp.StatusCode >= 400 {
+		fmt.Println("Delete task failed")
+		fmt.Println("This might be due to permission issues or endpoint-specific restrictions")
+	} else {
+		fmt.Println("Success! Delete task created successfully")
+		
+		// Parse response to get task ID
+		var taskResp struct {
+			TaskID string `json:"task_id"`
+		}
+		if err := json.Unmarshal(respBody, &taskResp); err != nil {
+			fmt.Printf("Failed to parse task response: %v\n", err)
+		} else {
+			fmt.Printf("Task ID: %s\n", taskResp.TaskID)
+		}
+	}
+}

--- a/debug/debug_delete_task.go
+++ b/debug/debug_delete_task.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/services/transfer"
+)
+
+// testAuthorizer implements the authorizer interface for testing
+type testAuthorizer struct {
+	token string
+}
+
+// GetAuthorizationHeader returns the authorization header value
+func (a *testAuthorizer) GetAuthorizationHeader(ctx ...context.Context) (string, error) {
+	return "Bearer " + a.token, nil
+}
+
+// IsValid returns whether the authorization is valid
+func (a *testAuthorizer) IsValid() bool {
+	return a.token != ""
+}
+
+// GetToken returns the token
+func (a *testAuthorizer) GetToken() string {
+	return a.token
+}
+
+func main() {
+	// Enable HTTP debugging
+	os.Setenv("HTTP_DEBUG", "true")
+
+	// Load environment variables
+	_ = godotenv.Load(".env.test")
+
+	// Get credentials from environment
+	accessToken := os.Getenv("GLOBUS_TEST_TRANSFER_TOKEN")
+	if accessToken == "" {
+		fmt.Println("ERROR: GLOBUS_TEST_TRANSFER_TOKEN environment variable is required")
+		os.Exit(1)
+	}
+
+	endpointID := os.Getenv("GLOBUS_TEST_SOURCE_ENDPOINT_ID")
+	if endpointID == "" {
+		fmt.Println("ERROR: GLOBUS_TEST_SOURCE_ENDPOINT_ID environment variable is required")
+		os.Exit(1)
+	}
+
+	// Create Transfer client with debugging enabled
+	client, err := transfer.NewClient(
+		transfer.WithAuthorizer(&testAuthorizer{token: accessToken}),
+		transfer.WithHTTPDebugging(true),
+	)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create transfer client: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Create a test directory to delete
+	timestamp := time.Now().Format("20060102_150405")
+	testPath := fmt.Sprintf("globus-test/debug_delete_%s", timestamp)
+	
+	fmt.Printf("Creating test directory: %s\n", testPath)
+	err = client.Mkdir(ctx, endpointID, testPath)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to create test directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Now attempt to delete the directory using DeleteTaskRequest
+	fmt.Println("\nAttempting to delete directory using DeleteTaskRequest...")
+	
+	deleteRequest := &transfer.DeleteTaskRequest{
+		DataType:   "delete",
+		Label:      fmt.Sprintf("Debug Delete Task %s", timestamp),
+		EndpointID: endpointID,
+		Items: []transfer.DeleteItem{
+			{
+				Path:      testPath,
+				Recursive: true,
+			},
+		},
+	}
+
+	// Execute the delete task
+	resp, err := client.CreateDeleteTask(ctx, deleteRequest)
+	if err != nil {
+		fmt.Printf("ERROR: Delete task failed: %v\n", err)
+		fmt.Println("\nPossible cause: DeleteItem might need a DATA_TYPE field similar to TransferItem")
+		fmt.Println("In the TransferTaskRequest implementation, each TransferItem gets a DataType if not set:")
+		fmt.Println("    if request.Items[i].DataType == \"\" {\n        request.Items[i].DataType = \"transfer_item\"\n    }")
+		fmt.Println("A similar fix might be needed for DeleteItem in CreateDeleteTask")
+	} else {
+		fmt.Printf("SUCCESS: Delete task created with task ID: %s\n", resp.TaskID)
+		
+		// Wait a moment and check task status
+		time.Sleep(2 * time.Second)
+		task, err := client.GetTask(ctx, resp.TaskID)
+		if err != nil {
+			fmt.Printf("ERROR: Failed to get task status: %v\n", err)
+		} else {
+			fmt.Printf("Task status: %s\n", task.Status)
+		}
+	}
+}

--- a/doc/IMPORT_CYCLE_FIX.md
+++ b/doc/IMPORT_CYCLE_FIX.md
@@ -1,0 +1,112 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors -->
+# Import Cycle Fix: Core and Transport Package
+
+This document explains the recent fix for the import cycle between the `pkg/core` and `pkg/core/transport` packages.
+
+## Problem Description
+
+An import cycle was present in the codebase between the following packages:
+
+- **core package** (`pkg/core/client.go`): imports `pkg/core/transport` to create a Transport instance
+- **transport package** (`pkg/core/transport/transport.go`): imports `pkg/core/interfaces` to reference the ClientInterface
+
+This circular dependency prevented the code from compiling and caused CI/CD workflows to fail.
+
+## Solution Implemented
+
+We implemented a solution based on the **deferred initialization** pattern with the following components:
+
+1. **DeferredTransport**: 
+   - Added a new struct in the transport package to hold transport configuration
+   - Allows creating transport settings without requiring the client instance
+
+2. **Transport Factory Function**:
+   - Created `InitTransport()` in a new file `pkg/core/transport_init.go`
+   - This function handles creating the transport with deferred initialization
+   - Breaks the import cycle by putting the client-to-transport connection in the core package
+
+3. **Interface-based Design**:
+   - Updated Client struct to use the Transport interface instead of concrete Transport type
+   - Simplified client options to rely on transport initialization in NewClient
+
+## Changes Made
+
+### 1. Updated `pkg/core/transport/transport.go`
+
+Added a DeferredTransport type and supporting functions:
+
+```go
+// DeferredTransport holds the transport configuration until a client is available
+type DeferredTransport struct {
+    Debug  bool
+    Trace  bool
+    Logger *log.Logger
+}
+
+// NewDeferredTransport creates a configuration for a transport that can be attached to a client later
+func NewDeferredTransport(options *Options) *DeferredTransport {
+    // Configuration setup logic
+    return &DeferredTransport{...}
+}
+
+// AttachClient creates a Transport by attaching a client to a DeferredTransport
+func (dt *DeferredTransport) AttachClient(client interfaces.ClientInterface) *Transport {
+    return &Transport{
+        Client: client,
+        Debug:  dt.Debug,
+        Trace:  dt.Trace,
+        Logger: dt.Logger,
+    }
+}
+```
+
+### 2. Created `pkg/core/transport_init.go`
+
+Created a new file to handle transport initialization:
+
+```go
+// InitTransport initializes a transport for a client
+// This function helps break the import cycle between core and transport packages
+func InitTransport(client interfaces.ClientInterface, debug, trace bool) interfaces.Transport {
+    // Create deferred transport first
+    dt := transport.NewDeferredTransport(&transport.Options{
+        Debug:  debug,
+        Trace:  trace,
+        Logger: loggerForTransport,
+    })
+    
+    // Now attach the client to create the actual transport
+    return dt.AttachClient(client)
+}
+```
+
+### 3. Updated `pkg/core/client.go`
+
+- Removed import of `github.com/scttfrdmn/globus-go-sdk/pkg/core/transport`
+- Changed `Transport` field type from `*transport.Transport` to `interfaces.Transport`
+- Updated `NewClient()` to use `InitTransport()` function
+- Simplified HTTP debugging and tracing options
+
+## Advantages of This Approach
+
+1. **No Import Cycle**: The circular dependency has been eliminated
+2. **Interface-based Design**: Code now depends on interfaces rather than concrete implementations
+3. **Better Testability**: Easier to create mock transports for testing
+4. **Cleaner Separation**: Clear boundaries between packages
+5. **Minimally Invasive**: No major refactoring required in the rest of the codebase
+
+## How It Works
+
+The key insight is pushing the integration code (creating the Transport with a Client) into the package that already has visibility of both types. By creating a "deferred" transport configuration in the transport package, we can later attach the client in the core package without directly importing the concrete Transport type.
+
+## Testing
+
+To verify this fix:
+1. Run `go build ./pkg/...` to ensure compilation works
+2. Run the unit tests for both packages to ensure functionality 
+3. Enable GitHub Actions workflows to verify CI/CD passes
+
+## Related Work
+
+For more comprehensive information about import cycle resolution in this project, see [IMPORT_CYCLE_RESOLUTION.md](IMPORT_CYCLE_RESOLUTION.md).

--- a/doc/REMAINING_FIXES.md
+++ b/doc/REMAINING_FIXES.md
@@ -1,0 +1,119 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors -->
+# Remaining Issues After Import Cycle Fix
+
+This document outlines the remaining issues that need to be addressed after fixing the import cycle between `pkg/core` and `pkg/core/transport`.
+
+## Current Status
+
+The primary import cycle between `pkg/core` and `pkg/core/transport` has been fixed. We can now successfully build:
+
+```bash
+go build ./pkg/core/...
+go build ./pkg/core/transport/...
+```
+
+However, there are still issues when building the entire package:
+
+```bash
+go build ./pkg/...
+```
+
+## Remaining Issues
+
+### 1. Auth Client API Changes
+
+The auth client constructor has been updated to use a functional options pattern, but not all code has been updated to use this new API.
+
+In `pkg/globus.go` line 58:
+```go
+authClient := auth.NewClient(c.ClientID, c.ClientSecret)
+```
+
+Needs to be updated to match the new API that returns a client and an error:
+```go
+authClient, err := auth.NewClient(auth.WithClientID(c.ClientID), auth.WithClientSecret(c.ClientSecret))
+if err != nil {
+    // Handle error
+}
+```
+
+### 2. Missing Client Options in Auth Package
+
+The auth package needs to define options like `WithClientID` and `WithClientSecret` to support the functional options pattern:
+
+```go
+// WithClientID sets the client ID
+func WithClientID(clientID string) ClientOption {
+    return func(c *Client) {
+        c.ClientID = clientID
+    }
+}
+
+// WithClientSecret sets the client secret
+func WithClientSecret(clientSecret string) ClientOption {
+    return func(c *Client) {
+        c.ClientSecret = clientSecret
+    }
+}
+```
+
+### 3. Similar Issues in Other Service Packages
+
+There are likely similar API mismatches in other service packages that need to be checked and updated.
+
+### 4. HTTP Pool Management
+
+The HTTP pool system (`httppool.GetHTTPClientForService`) may need to be updated to use the new interfaces-based approach.
+
+### 5. Example Files
+
+Many example files may need updates to work with the new API changes.
+
+## Action Plan
+
+1. **Fix Auth Package**:
+   - Create ClientOption functions
+   - Update method signatures
+   - Fix all return values to include error handling
+
+2. **Update Globus.go**:
+   - Update NewAuthClient to use the new Auth API
+   - Add proper error handling
+   - Ensure backwards compatibility where possible
+
+3. **Verify Other Services**:
+   - Check each service for similar issues
+   - Update service packages to use consistent patterns  
+
+4. **Revisit HTTP Pool**:
+   - Ensure HTTP pool management works with new interface-based approach
+   - Update any direct uses of concrete transport types
+
+5. **Fix Examples**:
+   - Update example code to work with the updated API
+   - Ensure examples follow current best practices
+
+## Testing Strategy
+
+1. Fix issues incrementally
+2. Build modules one at a time:
+   - `go build ./pkg/services/auth/...`
+   - `go build ./pkg/...`
+   - `go build ./cmd/...`
+3. Run tests with each change: `go test ./pkg/...`
+4. Once the code builds successfully, re-enable CI workflows
+
+## Next Steps
+
+Once the import cycle and related issues are fully resolved, we should:
+
+1. Update documentation to reflect the new design
+2. Re-enable GitHub Actions workflows
+3. Consider creating a standardized functional options pattern across all service clients
+
+## See Also
+
+- [IMPORT_CYCLE_FIX.md](IMPORT_CYCLE_FIX.md)
+- [IMPORT_CYCLE_RESOLUTION.md](IMPORT_CYCLE_RESOLUTION.md)
+- [GITHUB_ACTIONS_STATUS.md](GITHUB_ACTIONS_STATUS.md)

--- a/examples/connection-pooling/main.go
+++ b/examples/connection-pooling/main.go
@@ -52,9 +52,13 @@ func usingDefaultPool() {
 	config := pkg.NewConfigFromEnvironment()
 	
 	// Create multiple service clients
-	_ = config.NewAuthClient()
-	_ = config.NewTransferClient(os.Getenv("GLOBUS_ACCESS_TOKEN"))
-	_ = config.NewSearchClient(os.Getenv("GLOBUS_ACCESS_TOKEN"))
+	authClient, err := config.NewAuthClient()
+	if err != nil {
+		fmt.Printf("Failed to create auth client: %v\n", err)
+		return
+	}
+	transferClient := config.NewTransferClient(os.Getenv("GLOBUS_ACCESS_TOKEN"))
+	searchClient := config.NewSearchClient(os.Getenv("GLOBUS_ACCESS_TOKEN"))
 	
 	// The clients now share connection pools based on service type
 	fmt.Println("Created Auth, Transfer, and Search clients with connection pooling")

--- a/examples/token-management/main.go
+++ b/examples/token-management/main.go
@@ -24,7 +24,13 @@ func main() {
 
 	if clientID != "" && clientSecret != "" {
 		// Initialize the Globus Auth client
-		authClient := auth.NewClient(clientID, clientSecret)
+		authClient, err := auth.NewClient(
+			auth.WithClientID(clientID),
+			auth.WithClientSecret(clientSecret),
+		)
+		if err != nil {
+			log.Fatalf("Failed to create auth client: %v", err)
+		}
 		fmt.Println("Found Globus credentials, demonstrating with real auth client")
 		
 		// Demonstration of different token storage mechanisms

--- a/pkg/core/interfaces/transport.go
+++ b/pkg/core/interfaces/transport.go
@@ -26,4 +26,5 @@ type Transport interface {
 	Put(ctx context.Context, path string, body interface{}, query url.Values, headers http.Header) (*http.Response, error)
 	Delete(ctx context.Context, path string, query url.Values, headers http.Header) (*http.Response, error)
 	Patch(ctx context.Context, path string, body interface{}, query url.Values, headers http.Header) (*http.Response, error)
+	RoundTrip(req *http.Request) (*http.Response, error)
 }

--- a/pkg/core/transport/transport.go
+++ b/pkg/core/transport/transport.go
@@ -8,22 +8,121 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"time"
 
-	"github.com/scttfrdmn/globus-go-sdk/pkg/core"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/interfaces"
 )
 
 // Transport handles HTTP communication with the API
 type Transport struct {
-	Client *core.Client
+	Client interfaces.ClientInterface
+	Debug  bool
+	Trace  bool
+	Logger *log.Logger
+}
+
+// Options for configuring the transport
+type Options struct {
+	// Debug enables HTTP request/response logging
+	Debug bool
+	
+	// Trace enables detailed HTTP tracing (including bodies)
+	Trace bool
+	
+	// Logger is the logger to use for debug output
+	Logger *log.Logger
 }
 
 // NewTransport creates a new Transport
-func NewTransport(client *core.Client) *Transport {
+func NewTransport(client interfaces.ClientInterface, options *Options) *Transport {
+	// Check environment variables for debug settings
+	envDebug := os.Getenv("GLOBUS_SDK_HTTP_DEBUG") == "1"
+	envTrace := os.Getenv("GLOBUS_SDK_HTTP_TRACE") == "1"
+	
+	debug := envDebug
+	trace := envTrace
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	
+	// Override with options if provided
+	if options != nil {
+		if options.Debug {
+			debug = true
+		}
+		if options.Trace {
+			trace = true
+		}
+		if options.Logger != nil {
+			logger = options.Logger
+		}
+	}
+	
+	// If trace is enabled, debug is also enabled
+	if trace {
+		debug = true
+	}
+	
 	return &Transport{
 		Client: client,
+		Debug:  debug,
+		Trace:  trace,
+		Logger: logger,
+	}
+}
+
+// DeferredTransport holds the transport configuration until a client is available
+type DeferredTransport struct {
+	Debug  bool
+	Trace  bool
+	Logger *log.Logger
+}
+
+// NewDeferredTransport creates a configuration for a transport that can be attached to a client later
+func NewDeferredTransport(options *Options) *DeferredTransport {
+	// Check environment variables for debug settings
+	envDebug := os.Getenv("GLOBUS_SDK_HTTP_DEBUG") == "1"
+	envTrace := os.Getenv("GLOBUS_SDK_HTTP_TRACE") == "1"
+	
+	debug := envDebug
+	trace := envTrace
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+	
+	// Override with options if provided
+	if options != nil {
+		if options.Debug {
+			debug = true
+		}
+		if options.Trace {
+			trace = true
+		}
+		if options.Logger != nil {
+			logger = options.Logger
+		}
+	}
+	
+	// If trace is enabled, debug is also enabled
+	if trace {
+		debug = true
+	}
+	
+	return &DeferredTransport{
+		Debug:  debug,
+		Trace:  trace,
+		Logger: logger,
+	}
+}
+
+// AttachClient creates a Transport by attaching a client to a DeferredTransport
+func (dt *DeferredTransport) AttachClient(client interfaces.ClientInterface) *Transport {
+	return &Transport{
+		Client: client,
+		Debug:  dt.Debug,
+		Trace:  dt.Trace,
+		Logger: dt.Logger,
 	}
 }
 
@@ -37,7 +136,7 @@ func (t *Transport) Request(
 	headers http.Header,
 ) (*http.Response, error) {
 	// Build the full URL
-	urlStr := t.Client.BaseURL
+	urlStr := t.Client.GetBaseURL()
 	if !strings.HasSuffix(urlStr, "/") {
 		urlStr += "/"
 	}
@@ -48,9 +147,11 @@ func (t *Transport) Request(
 	}
 
 	// Prepare the request body
+	var bodyBytes []byte
 	var bodyReader io.Reader
 	if body != nil {
-		bodyBytes, err := json.Marshal(body)
+		var err error
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
@@ -82,10 +183,27 @@ func (t *Transport) Request(
 		req.Header.Set("Accept", "application/json")
 	}
 
+	// Log the request if debug is enabled
+	if t.Debug {
+		t.logRequest(method, urlStr, req.Header, bodyBytes)
+	}
+
 	// Send the request
+	startTime := time.Now()
 	resp, err := t.Client.Do(ctx, req)
+	duration := time.Since(startTime)
+
+	// Log the error if there is one
 	if err != nil {
+		if t.Debug {
+			t.Logger.Printf("HTTP Error: %v (%s)", err, duration.Round(time.Millisecond))
+		}
 		return nil, err
+	}
+
+	// Log the response if debug is enabled
+	if t.Debug {
+		t.logResponse(resp, duration)
 	}
 
 	return resp, nil

--- a/pkg/core/transport_init.go
+++ b/pkg/core/transport_init.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 Scott Friedman and Project Contributors
+package core
+
+import (
+	"log"
+	"os"
+
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/interfaces"
+	"github.com/scttfrdmn/globus-go-sdk/pkg/core/transport"
+)
+
+// InitTransport initializes a transport for a client
+// This function helps break the import cycle between core and transport packages
+func InitTransport(client interfaces.ClientInterface, debug, trace bool) interfaces.Transport {
+	loggerForTransport := log.New(os.Stderr, "", log.LstdFlags)
+	
+	// Create deferred transport first
+	dt := transport.NewDeferredTransport(&transport.Options{
+		Debug:  debug,
+		Trace:  trace,
+		Logger: loggerForTransport,
+	})
+	
+	// Now attach the client to create the actual transport
+	return dt.AttachClient(client)
+}

--- a/pkg/globus.go
+++ b/pkg/globus.go
@@ -54,8 +54,18 @@ type SDKConfig struct {
 }
 
 // NewAuthClient creates a new Auth client with the SDK configuration
-func (c *SDKConfig) NewAuthClient() *auth.Client {
-	authClient := auth.NewClient(c.ClientID, c.ClientSecret)
+func (c *SDKConfig) NewAuthClient() (*auth.Client, error) {
+	// Create auth client options
+	options := []auth.ClientOption{
+		auth.WithClientID(c.ClientID),
+		auth.WithClientSecret(c.ClientSecret),
+	}
+	
+	// Create the auth client
+	authClient, err := auth.NewClient(options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth client: %w", err)
+	}
 
 	// Apply configuration
 	if c.Config != nil {
@@ -68,7 +78,7 @@ func (c *SDKConfig) NewAuthClient() *auth.Client {
 		authClient.Client.HTTPClient = serviceClient
 	}
 
-	return authClient
+	return authClient, nil
 }
 
 // NewGroupsClient creates a new Groups client with the SDK configuration

--- a/pkg/integration_test_verify.go
+++ b/pkg/integration_test_verify.go
@@ -38,7 +38,10 @@ func TestIntegration_VerifySetup(t *testing.T) {
 
 	// Verify Auth credentials
 	fmt.Println("Verifying authentication credentials...")
-	authClient := config.NewAuthClient()
+	authClient, err := config.NewAuthClient()
+	if err != nil {
+		t.Fatalf("Failed to create auth client: %v", err)
+	}
 	ctx := context.Background()
 
 	// Try to get client credentials token
@@ -65,7 +68,7 @@ func TestIntegration_VerifySetup(t *testing.T) {
 
 	// Check for transfer endpoints if specified
 	sourceEndpointID := os.Getenv("GLOBUS_TEST_SOURCE_ENDPOINT_ID")
-	destEndpointID := os.Getenv("GLOBUS_TEST_DEST_ENDPOINT_ID")
+	destEndpointID := os.Getenv("GLOBUS_TEST_DESTINATION_ENDPOINT_ID")
 
 	if sourceEndpointID != "" && destEndpointID != "" {
 		fmt.Println("Verifying transfer endpoints...")
@@ -100,7 +103,10 @@ func verifyTransferEndpoints(t *testing.T, config *Config, sourceEndpointID, des
 	ctx := context.Background()
 
 	// We need a token with transfer scope
-	authClient := config.NewAuthClient()
+	authClient, err := config.NewAuthClient()
+	if err != nil {
+		t.Fatalf("Failed to create auth client: %v", err)
+	}
 	token, err := authClient.GetClientCredentialsToken(ctx, TransferScope)
 	if err != nil {
 		t.Fatalf("Failed to get token with transfer scope: %v", err)


### PR DESCRIPTION
# Example Applications Syntax Error Fixes

This PR fixes syntax errors in the example applications to ensure they build successfully with the current SDK API.

## Changes

### Core Interfaces

- Added `RoundTrip` method to the Transport interface to support low-level HTTP operations in debugging tools
- Implemented the RoundTrip method in the Transport implementation

### Auth Client Usage

- Updated all example applications to use the new functional options pattern for auth client creation
- Fixed error handling for the auth client creation, which now returns an error that must be checked

### String Literal Fixes

- Fixed newline syntax errors in string literals, particularly in the flows and search examples
- Replaced all newline-containing string literals with proper `\n` escapes

### Transfer API Fixes

- Fixed `DATA` vs `Data` field in transfer endpoint list
- Removed incorrect `Recursive` field from `DeleteItem`, which is not supported by the Transfer API
- Updated TransferOptions to use map[string]interface{} type in transfer example

### Organization

- Moved debug files from the root directory to a dedicated `debug/` directory
- Moved multiple debug files in cmd/examples/debugging to avoid conflicting main functions

## Testing

All example applications now build successfully:

```bash
go build ./cmd/examples/flows/main.go
go build ./cmd/examples/search/main.go
go build ./cmd/examples/transfer/main.go
go build ./cmd/examples/debugging/main.go
```

## Related Issues

This PR fixes buildability issues with the example applications, which were preventing users from running the examples to understand how to use the SDK.