### PR TITLE
feat(v4): RBAC/introspection modeling for arpeggio (issues #50–#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Auth & Groups RBAC/introspection modeling (v4 module; issues #50–#52)
+
+Enhancements requested by the arpeggio portal (RBAC + DUA audit trails):
+
+- **groups #50**: `Group` gained `MyMemberships []Member` (`my_memberships`), and
+  `GetMyGroupsWithOptions(ctx, *GetMyGroupsOptions)` sends `include=my_memberships`
+  so the caller's **role** (member/manager/admin) is recoverable — previously the
+  Group-level `IsGroupAdmin`/`IsMember` bools collapsed manager into member.
+- **auth #51**: `TokenIntrospection` gained `Organization` and
+  `IdentitySetDetail []Identity` (`include=identity_set_detail`, full linked-identity
+  records inline — no second `GetIdentities` call); `Identity` gained
+  `IdentityType` (login vs link).
+- **auth #52**: added `authorizers.NewBasicAuthAuthorizer(clientID, clientSecret)`
+  for HTTP Basic client authentication, and documented on `IntrospectToken`/
+  `GetDependentTokens` that a confidential client must use it (those endpoints
+  authenticate the client per RFC 7662, not a user Bearer token).
+
 ### Fixed (v4 module — `github.com/scttfrdmn/globus-go-sdk/v4`)
 
 Core wire-fidelity fixes from the Phase 2 parity audit against Python

--- a/v4/pkg/authorizers/basic_auth.go
+++ b/v4/pkg/authorizers/basic_auth.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package authorizers
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/core"
+)
+
+// BasicAuthAuthorizer authenticates as an OAuth2 confidential client using HTTP
+// Basic auth (client_id:client_secret). This is the mechanism the token
+// introspection (RFC 7662) and dependent-token endpoints expect for client
+// authentication — they authenticate the client, not a user bearer token. It
+// implements core.Authorizer.
+type BasicAuthAuthorizer struct {
+	clientID     string
+	clientSecret string
+}
+
+// NewBasicAuthAuthorizer creates an authorizer that sends
+// "Basic base64(clientID:clientSecret)".
+func NewBasicAuthAuthorizer(clientID, clientSecret string) core.Authorizer {
+	return &BasicAuthAuthorizer{clientID: clientID, clientSecret: clientSecret}
+}
+
+// GetAuthorizationHeader returns the Basic authorization header.
+func (a *BasicAuthAuthorizer) GetAuthorizationHeader(_ context.Context) (string, error) {
+	if a.clientID == "" {
+		return "", &core.ValidationError{Field: "clientID", Message: "client ID is empty"}
+	}
+	creds := a.clientID + ":" + a.clientSecret
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(creds)), nil
+}
+
+// HandleMissingAuthorization always returns false — client credentials are
+// static and cannot be refreshed.
+func (a *BasicAuthAuthorizer) HandleMissingAuthorization(_ context.Context) bool {
+	return false
+}

--- a/v4/pkg/authorizers/basic_auth_test.go
+++ b/v4/pkg/authorizers/basic_auth_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package authorizers_test
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/authorizers"
+)
+
+func TestBasicAuthAuthorizer(t *testing.T) {
+	a := authorizers.NewBasicAuthAuthorizer("client-id", "secret")
+	got, err := a.GetAuthorizationHeader(context.Background())
+	if err != nil {
+		t.Fatalf("GetAuthorizationHeader: %v", err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("client-id:secret"))
+	if got != want {
+		t.Errorf("header = %q, want %q", got, want)
+	}
+	if a.HandleMissingAuthorization(context.Background()) {
+		t.Error("HandleMissingAuthorization should be false for static client credentials")
+	}
+}
+
+func TestBasicAuthAuthorizer_EmptyClientID(t *testing.T) {
+	a := authorizers.NewBasicAuthAuthorizer("", "secret")
+	if _, err := a.GetAuthorizationHeader(context.Background()); err == nil {
+		t.Error("expected error for empty client ID")
+	}
+}

--- a/v4/pkg/services/auth/client.go
+++ b/v4/pkg/services/auth/client.go
@@ -55,6 +55,13 @@ func (c *Client) GetUserInfo(ctx context.Context) (*UserInfo, error) {
 // the OAuth2 introspection spec. Pass opts.Include (e.g. "identity_set") to
 // request extra fields; opts may be nil.
 // v4: Context is always first parameter
+// IntrospectToken introspects an OAuth2 token (POST /oauth2/token/introspect).
+//
+// This endpoint authenticates the *client*, not a user. A confidential client
+// must construct the auth Client with a client-authenticating authorizer —
+// authorizers.NewBasicAuthAuthorizer(clientID, clientSecret) — so the request
+// carries "Authorization: Basic base64(id:secret)" as RFC 7662 requires. A
+// user Bearer token is not accepted here.
 func (c *Client) IntrospectToken(ctx context.Context, token string, opts *IntrospectOptions) (*TokenIntrospection, error) {
 	if token == "" {
 		return nil, &core.ValidationError{

--- a/v4/pkg/services/auth/introspect_detail_test.go
+++ b/v4/pkg/services/auth/introspect_detail_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/testhelpers"
+)
+
+// TestIntrospectIdentitySetDetail verifies the fields added for issue #51:
+// organization on the introspection result, and a detailed linked-identity set
+// (with identity_type) via include=identity_set_detail.
+func TestIntrospectIdentitySetDetail(t *testing.T) {
+	server := testhelpers.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.PostForm.Get("include"); got != "identity_set_detail" {
+			t.Errorf("include = %q, want identity_set_detail", got)
+		}
+		testhelpers.RespondJSON(w, http.StatusOK, map[string]interface{}{
+			"active":       true,
+			"sub":          "primary-uuid",
+			"username":     "user@example.org",
+			"organization": "Example Org",
+			"identity_set_detail": []map[string]interface{}{
+				{"id": "primary-uuid", "username": "user@example.org", "organization": "Example Org", "identity_type": "login"},
+				{"id": "linked-uuid", "username": "user@orcid", "identity_type": "link"},
+			},
+		})
+	})
+	client, err := auth.NewClient(context.Background(), testhelpers.NewTestConfig(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	res, err := client.IntrospectToken(context.Background(), "tok", &auth.IntrospectOptions{Include: "identity_set_detail"})
+	if err != nil {
+		t.Fatalf("IntrospectToken: %v", err)
+	}
+	if res.Organization != "Example Org" {
+		t.Errorf("Organization = %q, want Example Org", res.Organization)
+	}
+	if len(res.IdentitySetDetail) != 2 {
+		t.Fatalf("IdentitySetDetail len = %d, want 2", len(res.IdentitySetDetail))
+	}
+	if res.IdentitySetDetail[0].IdentityType != "login" || res.IdentitySetDetail[1].IdentityType != "link" {
+		t.Errorf("identity_type not decoded: %+v", res.IdentitySetDetail)
+	}
+	if res.IdentitySetDetail[1].Username != "user@orcid" {
+		t.Errorf("linked username = %q", res.IdentitySetDetail[1].Username)
+	}
+}

--- a/v4/pkg/services/auth/models.go
+++ b/v4/pkg/services/auth/models.go
@@ -16,21 +16,27 @@ type UserInfo struct {
 
 // TokenIntrospection represents the result of token introspection
 type TokenIntrospection struct {
-	Active      bool     `json:"active"`
-	Scope       string   `json:"scope,omitempty"`
-	ClientID    string   `json:"client_id,omitempty"`
-	Username    string   `json:"username,omitempty"`
-	TokenType   string   `json:"token_type,omitempty"`
-	Exp         int64    `json:"exp,omitempty"`
-	Iat         int64    `json:"iat,omitempty"`
-	Nbf         int64    `json:"nbf,omitempty"`
-	Sub         string   `json:"sub,omitempty"`
-	Aud         []string `json:"aud,omitempty"`
-	Iss         string   `json:"iss,omitempty"`
-	Jti         string   `json:"jti,omitempty"`
-	Name        string   `json:"name,omitempty"`
-	Email       string   `json:"email,omitempty"`
-	IdentitySet []string `json:"identity_set,omitempty"` // populated when include=identity_set
+	Active       bool     `json:"active"`
+	Scope        string   `json:"scope,omitempty"`
+	ClientID     string   `json:"client_id,omitempty"`
+	Username     string   `json:"username,omitempty"`
+	TokenType    string   `json:"token_type,omitempty"`
+	Exp          int64    `json:"exp,omitempty"`
+	Iat          int64    `json:"iat,omitempty"`
+	Nbf          int64    `json:"nbf,omitempty"`
+	Sub          string   `json:"sub,omitempty"`
+	Aud          []string `json:"aud,omitempty"`
+	Iss          string   `json:"iss,omitempty"`
+	Jti          string   `json:"jti,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Email        string   `json:"email,omitempty"`
+	Organization string   `json:"organization,omitempty"`
+	// IdentitySet holds the linked identity UUIDs, populated when
+	// include=identity_set.
+	IdentitySet []string `json:"identity_set,omitempty"`
+	// IdentitySetDetail holds the full linked-identity records, populated when
+	// include=identity_set_detail — avoiding a second GetIdentities round trip.
+	IdentitySetDetail []Identity `json:"identity_set_detail,omitempty"`
 }
 
 // TokenResponse represents an OAuth2 token response. When a single token request

--- a/v4/pkg/services/auth/resource_methods.go
+++ b/v4/pkg/services/auth/resource_methods.go
@@ -380,6 +380,11 @@ func (c *Client) GetConsents(ctx context.Context, identityID string, all bool) (
 
 // GetDependentTokens performs the dependent-token grant (POST /oauth2/token),
 // returning one token per dependent resource server.
+//
+// Like introspection, this grant authenticates the *client*. A confidential
+// client must construct the auth Client with
+// authorizers.NewBasicAuthAuthorizer(clientID, clientSecret) so the request is
+// client-authenticated via HTTP Basic auth.
 func (c *Client) GetDependentTokens(ctx context.Context, token string, opts *DependentTokensOptions) ([]DependentTokenInfo, error) {
 	if token == "" {
 		return nil, &core.ValidationError{Field: "token", Message: "token is required"}

--- a/v4/pkg/services/auth/resources.go
+++ b/v4/pkg/services/auth/resources.go
@@ -13,6 +13,9 @@ type Identity struct {
 	Organization     string `json:"organization"`
 	IdentityProvider string `json:"identity_provider"`
 	Status           string `json:"status"`
+	// IdentityType distinguishes a login identity from a linked identity
+	// ("login" vs "link"), returned by GetIdentities and in identity_set_detail.
+	IdentityType string `json:"identity_type,omitempty"`
 }
 
 // IdentityProvider represents a Globus Auth identity provider.
@@ -218,7 +221,10 @@ type DependentTokenInfo struct {
 
 // IntrospectOptions carries optional parameters for IntrospectToken.
 type IntrospectOptions struct {
-	Include string // e.g. "identity_set"
+	// Include is the comma-separated introspection include set, e.g.
+	// "identity_set" (UUIDs, into IdentitySet) or "identity_set_detail" (full
+	// records, into IdentitySetDetail).
+	Include string
 }
 
 // GetIdentitiesOptions controls GetIdentities. Usernames and IDs are mutually

--- a/v4/pkg/services/groups/client.go
+++ b/v4/pkg/services/groups/client.go
@@ -74,6 +74,28 @@ func (c *Client) GetMyGroups(ctx context.Context, statuses []string) ([]Group, e
 	return out, nil
 }
 
+// GetMyGroupsWithOptions lists the caller's groups (GET /groups/my_groups) with
+// optional status filtering and includes. Pass Include=["my_memberships"] to
+// populate each returned group's MyMemberships, which carries the caller's role
+// (member/manager/admin) — not derivable from the Group-level bool fields.
+func (c *Client) GetMyGroupsWithOptions(ctx context.Context, opts *GetMyGroupsOptions) ([]Group, error) {
+	query := url.Values{}
+	if opts != nil {
+		if len(opts.Statuses) > 0 {
+			query.Set("statuses", strings.Join(opts.Statuses, ","))
+		}
+		if len(opts.Include) > 0 {
+			query.Set("include", strings.Join(opts.Include, ","))
+		}
+	}
+
+	var out []Group
+	if err := c.baseClient.DoRequest(ctx, http.MethodGet, "/groups/my_groups", query, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // GetGroupBySubscriptionID looks up the group associated with a subscription
 // (GET /subscription_info/{subscription_id}).
 func (c *Client) GetGroupBySubscriptionID(ctx context.Context, subscriptionID string) (*Group, error) {

--- a/v4/pkg/services/groups/models.go
+++ b/v4/pkg/services/groups/models.go
@@ -24,6 +24,11 @@ type Group struct {
 	// Memberships is populated only when a group is fetched with
 	// include=memberships; the Groups API has no separate members endpoint.
 	Memberships []Member `json:"memberships,omitempty"`
+	// MyMemberships holds the caller's own membership(s) in the group, populated
+	// only with include=my_memberships. Each entry carries the caller's Role
+	// (member/manager/admin) — the only way to distinguish manager from member,
+	// since the Group-level IsGroupAdmin/IsMember bools cannot.
+	MyMemberships []Member `json:"my_memberships,omitempty"`
 }
 
 // GroupCreate represents the data needed to create a new group
@@ -55,6 +60,15 @@ type GroupUpdate struct {
 // allowed_actions, child_ids).
 type GetGroupOptions struct {
 	Include []string
+}
+
+// GetMyGroupsOptions controls GetMyGroupsWithOptions. Statuses filters by
+// membership status; Include is comma-joined into the `include` query param.
+// Use include=my_memberships to populate each group's MyMemberships (and thus
+// the caller's role).
+type GetMyGroupsOptions struct {
+	Statuses []string
+	Include  []string
 }
 
 // Member represents a group membership entry, as embedded in a group document

--- a/v4/pkg/services/groups/my_memberships_test.go
+++ b/v4/pkg/services/groups/my_memberships_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package groups_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/groups"
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/testhelpers"
+)
+
+// TestGetMyGroupsWithOptions_MyMembershipsRole verifies that include=my_memberships
+// is sent and that the caller's role decodes into Group.MyMemberships — the fix
+// for the manager-vs-member gap (issue #50).
+func TestGetMyGroupsWithOptions_MyMembershipsRole(t *testing.T) {
+	server := testhelpers.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("include"); got != "my_memberships" {
+			t.Errorf("include = %q, want my_memberships", got)
+		}
+		if got := r.URL.Query().Get("statuses"); got != "active" {
+			t.Errorf("statuses = %q, want active", got)
+		}
+		testhelpers.RespondJSON(w, http.StatusOK, []map[string]interface{}{
+			{
+				"id":   "grp-1",
+				"name": "Managed Group",
+				"my_memberships": []map[string]interface{}{
+					{"identity_id": "id-1", "role": "manager", "status": "active"},
+				},
+			},
+		})
+	})
+	client, err := groups.NewClient(context.Background(), testhelpers.NewTestConfig(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	out, err := client.GetMyGroupsWithOptions(context.Background(), &groups.GetMyGroupsOptions{
+		Statuses: []string{"active"},
+		Include:  []string{"my_memberships"},
+	})
+	if err != nil {
+		t.Fatalf("GetMyGroupsWithOptions: %v", err)
+	}
+	if len(out) != 1 || len(out[0].MyMemberships) != 1 {
+		b, _ := json.Marshal(out)
+		t.Fatalf("unexpected result: %s", b)
+	}
+	if role := out[0].MyMemberships[0].Role; role != "manager" {
+		t.Errorf("caller role = %q, want manager (must be distinguishable from member)", role)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the three arpeggio-portal issues (#50, #51, #52) — all v4-labeled,
driven by RBAC and DUA-audit needs. Verified each against the current v4 code
before implementing.

## #50 — groups: caller's role (manager vs member)

`GetMyGroups` sent no `include` and `Group` had no per-caller membership, so
`manager` was indistinguishable from `member` (only `IsGroupAdmin`/`IsMember`
bools). Added:
- `Group.MyMemberships []Member` (`json:"my_memberships"`).
- `GetMyGroupsWithOptions(ctx, *GetMyGroupsOptions)` — sends `statuses` and
  `include` (e.g. `my_memberships`), so `MyMemberships[].Role` gives the caller's
  role. The existing `GetMyGroups(ctx, statuses)` is unchanged.

## #51 — auth: fuller linked-identity set from introspection

- `TokenIntrospection.Organization` added.
- `TokenIntrospection.IdentitySetDetail []Identity` added
  (`include=identity_set_detail`) — full linked-identity records inline, removing
  the second `GetIdentities` round trip.
- `Identity.IdentityType` added (login vs link). `IntrospectOptions.Include`
  documented for `identity_set_detail`.

## #52 — auth: confidential-client authentication (answer + fix)

Confirmed the gap: `IntrospectToken`/`GetDependentTokens` authenticate the
**client** (HTTP Basic per RFC 7662), but the v4 core client only ever sends
`Authorization: Bearer …` — no Basic path. Added:
- `authorizers.NewBasicAuthAuthorizer(clientID, clientSecret)` → sends
  `Basic base64(id:secret)` through the existing authorizer header path.
- Doc comments on `IntrospectToken` and `GetDependentTokens` instructing
  confidential clients to construct the auth client with it.

So the answer to the question in #52 is: **use Basic auth, now via
`NewBasicAuthAuthorizer`** — not the ClientCredentials (Bearer) authorizer.

## Testing

New tests: basic-auth header (+ empty-clientID error); `my_memberships` role
decode with `include=my_memberships` assertion; introspection `organization` +
`identity_set_detail`/`identity_type` decode with `include` assertion. Full v4
module `go build/vet/test ./...` green.

## Caveats

- **Wire shapes not confirmed against live Globus.** The `my_memberships` and
  `identity_set_detail` field names/shapes are modeled from the issue reports and
  Globus API docs; tests use mock servers. A live call would confirm the exact
  JSON. Worth validating before relying on the audit trail.
- **#52 assumes Basic auth is what Globus expects** on those endpoints (the RFC
  7662 standard and the arpeggio stand-in's current behavior). If Globus also
  accepts a client Bearer token, the ClientCredentials authorizer would work too;
  Basic is the spec-standard, safe choice.