### PR TITLE
fix(transfer): decode endpoint keywords as string or array (found by dogfooding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Transfer endpoint keywords string/array (both v3 and v4 modules)
+
+Found by dogfooding the Go CLI against live Globus: `endpoint search` failed with
+`cannot unmarshal string into ... keywords of type []string`. The Transfer API
+returns an endpoint's `keywords` as **either** a JSON array or a single
+comma-separated string. `Endpoint.Keywords` is now a `Keywords` type that
+unmarshals both forms into `[]string` (underlying type unchanged, so existing
+`[]string` usage is unaffected).
+
 ### Added — Auth & Groups RBAC/introspection modeling (v4 module; issues #50–#52)
 
 Enhancements requested by the arpeggio portal (RBAC + DUA audit trails):

--- a/pkg/services/transfer/keywords_test.go
+++ b/pkg/services/transfer/keywords_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestKeywordsUnmarshal covers both wire forms the Transfer API uses for the
+// endpoint "keywords" field: a JSON array and a comma-separated string. The
+// string form was found by dogfooding against live Globus (endpoint search),
+// where the []string model failed to unmarshal.
+func TestKeywordsUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"array", `["a","b","c"]`, []string{"a", "b", "c"}},
+		{"comma string", `"Globus,demo,tutorial"`, []string{"Globus", "demo", "tutorial"}},
+		{"string with spaces", `"a, b , c"`, []string{"a", "b", "c"}},
+		{"empty string", `""`, nil},
+		{"empty array", `[]`, []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var k Keywords
+			if err := json.Unmarshal([]byte(tc.in), &k); err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tc.in, err)
+			}
+			if len(k) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(k), len(tc.want), k)
+			}
+			for i := range tc.want {
+				if k[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, k[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestEndpointDecodesStringKeywords is a regression test for the live-data shape
+// that broke `globus transfer endpoint search`: an endpoint whose keywords are a
+// bare comma-separated string.
+func TestEndpointDecodesStringKeywords(t *testing.T) {
+	raw := `{"id":"ep-1","display_name":"Tutorial","keywords":"Globus,demo,tutorial,1"}`
+	var ep Endpoint
+	if err := json.Unmarshal([]byte(raw), &ep); err != nil {
+		t.Fatalf("Unmarshal endpoint: %v", err)
+	}
+	if len(ep.Keywords) != 4 || ep.Keywords[0] != "Globus" {
+		t.Errorf("keywords = %v, want [Globus demo tutorial 1]", ep.Keywords)
+	}
+}

--- a/pkg/services/transfer/models.go
+++ b/pkg/services/transfer/models.go
@@ -4,8 +4,39 @@ package transfer
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 )
+
+// Keywords is a list of endpoint keywords. The Transfer API is inconsistent on
+// the wire: some endpoints return keywords as a JSON array, others as a single
+// comma-separated string. Keywords unmarshals both forms into a []string.
+type Keywords []string
+
+// UnmarshalJSON accepts either ["a","b"] or "a,b".
+func (k *Keywords) UnmarshalJSON(data []byte) error {
+	// Try an array first.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*k = arr
+		return nil
+	}
+	// Fall back to a comma-separated string.
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		*k = nil
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	*k = parts
+	return nil
+}
 
 const (
 	// SyncLevel constants define how to synchronize files
@@ -30,7 +61,7 @@ type Endpoint struct {
 	OwnerID                string                 `json:"owner_id"`
 	Organization           string                 `json:"organization,omitempty"`
 	Department             string                 `json:"department,omitempty"`
-	Keywords               []string               `json:"keywords,omitempty"`
+	Keywords               Keywords               `json:"keywords,omitempty"`
 	ContactEmail           string                 `json:"contact_email,omitempty"`
 	ContactInfo            string                 `json:"contact_info,omitempty"`
 	Public                 bool                   `json:"public"`

--- a/v4/pkg/services/transfer/keywords_test.go
+++ b/v4/pkg/services/transfer/keywords_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package transfer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestKeywordsUnmarshal covers both wire forms of the endpoint "keywords" field
+// (array and comma-separated string). The string form was found by dogfooding
+// against live Globus.
+func TestKeywordsUnmarshal(t *testing.T) {
+	var k Keywords
+	if err := json.Unmarshal([]byte(`"Globus,demo,tutorial"`), &k); err != nil {
+		t.Fatalf("string form: %v", err)
+	}
+	if len(k) != 3 || k[0] != "Globus" {
+		t.Errorf("string form = %v", k)
+	}
+	if err := json.Unmarshal([]byte(`["a","b"]`), &k); err != nil {
+		t.Fatalf("array form: %v", err)
+	}
+	if len(k) != 2 || k[1] != "b" {
+		t.Errorf("array form = %v", k)
+	}
+}

--- a/v4/pkg/services/transfer/models.go
+++ b/v4/pkg/services/transfer/models.go
@@ -2,7 +2,39 @@
 // SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 package transfer
 
-import "time"
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// Keywords is a list of endpoint keywords. The Transfer API returns keywords as
+// either a JSON array or a single comma-separated string depending on the
+// endpoint; Keywords unmarshals both into a []string.
+type Keywords []string
+
+// UnmarshalJSON accepts either ["a","b"] or "a,b".
+func (k *Keywords) UnmarshalJSON(data []byte) error {
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*k = arr
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		*k = nil
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	*k = parts
+	return nil
+}
 
 // Endpoint represents a Globus Transfer endpoint
 type Endpoint struct {
@@ -14,7 +46,7 @@ type Endpoint struct {
 	Description          string    `json:"description,omitempty"`
 	Organization         string    `json:"organization,omitempty"`
 	Department           string    `json:"department,omitempty"`
-	Keywords             []string  `json:"keywords,omitempty"`
+	Keywords             Keywords  `json:"keywords,omitempty"`
 	MyEffectiveRoles     []string  `json:"my_effective_roles,omitempty"`
 	SubscriptionID       string    `json:"subscription_id,omitempty"`
 	NetworkUse           string    `json:"network_use,omitempty"`


### PR DESCRIPTION
## Summary

**Found by dogfooding** the Go CLI against **live Globus** — the kind of bug mock
tests can't catch. Running `globus transfer endpoint search "Globus Tutorial"`
against the real API failed:

```
Error: failed to list endpoints: failed to unmarshal response:
  json: cannot unmarshal string into Go struct field Endpoint.DATA.keywords of type []string
```

The Transfer API returns an endpoint's `keywords` as **either** a JSON array
(`["a","b"]`) or a single **comma-separated string** (`"Globus,demo,tutorial"`),
depending on the endpoint. Our models hardcoded `[]string`, so real data broke.

## Fix

Add a `Keywords []string` type with a flexible `UnmarshalJSON` that accepts both
forms (array as-is; string comma-split + trimmed), and use it for
`Endpoint.Keywords` in **both** the v3 and v4 modules. Underlying type is still
`[]string`, so existing `[]string` usage is unaffected (no callers reference the
field anyway).

## Verification

- New unit tests cover both wire forms + the regression endpoint document.
- `go build/test ./...` green in both modules.
- **Confirmed live**: after the fix, `endpoint search` against real Globus returns
  results correctly, and `-F json` shows `keywords` decoded as an array.

## Note

This came out of a live dogfooding pass with a client-credentials token. That
pass also validated (against live Globus) that Phase 1's `-F json`, `--jq`
(output matches the Python CLI), and `--map-http-status` (a real 403 → exit 51)
all work end-to-end.