### PR TITLE
feat(v4): GCS manage_collections endpoint scope helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — GCS manage_collections endpoint scope helper (v4 module)
+
+`gcs.EndpointManageCollectionsScope(endpointID)` returns the endpoint's
+`urn:globus:auth:scope:<endpoint_id>:manage_collections` scope, required for GCS
+Manager management operations (list/create/delete collections, storage gateways,
+roles, user credentials). The existing `CollectionScopes` only covered the
+collection data-plane scopes (`https`/`data_access`, URL format); management
+needs this endpoint scope in URN format. Verified against globus-sdk-python
+`GCSEndpointScopes`/`GCSCollectionScopes`.
+
 ### Added — GCSv5 endpoint fields + token session_info (v4 module)
 
 Requested by the Go CLI to unblock `collection`/`gcs` and `session` commands.

--- a/v4/pkg/services/gcs/client_test.go
+++ b/v4/pkg/services/gcs/client_test.go
@@ -314,3 +314,15 @@ func TestClose(t *testing.T) {
 	assert.NoError(t, client.Close())
 	assert.NoError(t, client.Close())
 }
+
+// TestScopeHelpers verifies the collection (URL-format) and endpoint
+// (URN-format) scope strings, matching globus-sdk-python's GCSCollectionScopes
+// and GCSEndpointScopes.
+func TestScopeHelpers(t *testing.T) {
+	https, dataAccess := gcs.CollectionScopes("col-123")
+	assert.Equal(t, "https://auth.globus.org/scopes/col-123/https", https)
+	assert.Equal(t, "https://auth.globus.org/scopes/col-123/data_access", dataAccess)
+
+	manage := gcs.EndpointManageCollectionsScope("ep-456")
+	assert.Equal(t, "urn:globus:auth:scope:ep-456:manage_collections", manage)
+}

--- a/v4/pkg/services/gcs/models.go
+++ b/v4/pkg/services/gcs/models.go
@@ -239,8 +239,21 @@ type UserCredentialListOptions struct {
 // CollectionScopes returns the standard Globus scope strings for a collection.
 // HTTPS scope is required for data-plane file access.
 // DataAccess scope is required for transfer task submission to the collection.
+//
+// These are "collection" scopes in URL format, keyed by the collection ID (the
+// data-access resource server). See globus-sdk-python GCSCollectionScopes.
 func CollectionScopes(collectionID string) (https, dataAccess string) {
 	https = fmt.Sprintf("https://auth.globus.org/scopes/%s/https", collectionID)
 	dataAccess = fmt.Sprintf("https://auth.globus.org/scopes/%s/data_access", collectionID)
 	return
+}
+
+// EndpointManageCollectionsScope returns the GCS endpoint's manage_collections
+// scope, required for management operations against the GCS Manager API
+// (listing/creating/deleting collections, storage gateways, roles, and user
+// credentials). Unlike the collection data-plane scopes, this is an endpoint
+// scope in Globus Auth URN format, keyed by the endpoint ID. See
+// globus-sdk-python GCSEndpointScopes.
+func EndpointManageCollectionsScope(endpointID string) string {
+	return fmt.Sprintf("urn:globus:auth:scope:%s:manage_collections", endpointID)
 }


### PR DESCRIPTION
Adds `gcs.EndpointManageCollectionsScope(endpointID)` →
`urn:globus:auth:scope:<endpoint_id>:manage_collections`, the scope required for
GCS Manager **management** operations (collections / storage gateways / roles /
user credentials CRUD).

The existing `CollectionScopes` only builds the collection **data-plane** scopes
(`https` / `data_access`, in URL format). Management uses an **endpoint** scope
in **URN** format — a different key and format. Verified against
globus-sdk-python `GCSEndpointScopes` / `GCSCollectionScopes`.

Unblocks the Go CLI's `collection`/`gcs` management commands, which need this
scope for the GlobusApp consent-escalation login. Test added; `ported` stays
`v4.8.1`.