### PR TITLE
feat(v4): session_required params on the login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — session enforcement params on the login flow (v4 module)
+
+`login.AuthParams` gained `SessionRequiredIdentities`, `SessionRequiredSingleDomain`,
+`SessionRequiredPolicies`, `SessionRequiredMFA`, and `SessionMessage`, and the
+command-line login flow now emits the corresponding `session_required_*` /
+`session_message` parameters on the authorization URL. This lets a caller force
+step-up re-authentication of specific identities/domains/policies during login —
+the mechanism behind a CLI `session update`. (These params already existed on
+`auth.AuthorizationURLOptions`; this threads them through the login-flow manager.)
+Verified against the `GetAuthorizationURL` param names.
+
 ### Added — GCS manage_collections endpoint scope helper (v4 module)
 
 `gcs.EndpointManageCollectionsScope(endpointID)` returns the endpoint's

--- a/v4/pkg/login/authurl_internal_test.go
+++ b/v4/pkg/login/authurl_internal_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package login
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestBuildAuthURLSessionParams verifies that the session-enforcement
+// (step-up auth) parameters on AuthParams are emitted on the authorization URL,
+// which is what powers a CLI `session update`.
+func TestBuildAuthURLSessionParams(t *testing.T) {
+	m := NewCommandLineLoginFlowManager("client-abc", "")
+
+	params := AuthParams{
+		Scopes:                      []string{"openid"},
+		SessionRequiredIdentities:   []string{"id-1", "id-2"},
+		SessionRequiredSingleDomain: []string{"example.org"},
+		SessionRequiredPolicies:     []string{"pol-1"},
+		SessionRequiredMFA:          true,
+		SessionMessage:              "please re-authenticate",
+	}
+
+	raw := m.buildAuthURL(params.Scopes, "https://example.org/cb", "", params)
+	u, err := parseQuery(raw)
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+
+	checks := map[string]string{
+		"session_required_identities":    "id-1,id-2",
+		"session_required_single_domain": "example.org",
+		"session_required_policies":      "pol-1",
+		"session_required_mfa":           "true",
+		"session_message":                "please re-authenticate",
+	}
+	for k, want := range checks {
+		if got := u.Get(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+
+	// Absent when unset: a bare params object must emit no session_* keys.
+	bare := m.buildAuthURL([]string{"openid"}, "https://example.org/cb", "", AuthParams{Scopes: []string{"openid"}})
+	if strings.Contains(bare, "session_required") || strings.Contains(bare, "session_message") {
+		t.Errorf("unexpected session params in URL with none set: %s", bare)
+	}
+}
+
+// parseQuery extracts the query values from an authorization URL.
+func parseQuery(raw string) (url.Values, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	return u.Query(), nil
+}

--- a/v4/pkg/login/command_line.go
+++ b/v4/pkg/login/command_line.go
@@ -84,7 +84,7 @@ func (m *CommandLineLoginFlowManager) RunLoginFlow(ctx context.Context, params A
 		redirectURI = params.RedirectURI
 	}
 
-	authURL := m.buildAuthURL(scopes, redirectURI, params.State)
+	authURL := m.buildAuthURL(scopes, redirectURI, params.State, params)
 
 	fmt.Println("Please open the following URL in your browser to authenticate:")
 	fmt.Println()
@@ -108,7 +108,7 @@ func (m *CommandLineLoginFlowManager) RunLoginFlow(ctx context.Context, params A
 }
 
 // buildAuthURL constructs the Globus Auth authorization URL.
-func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI, state string) string {
+func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI, state string, params AuthParams) string {
 	q := url.Values{}
 	q.Set("response_type", "code")
 	q.Set("client_id", m.clientID)
@@ -118,6 +118,22 @@ func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI,
 	}
 	if state != "" {
 		q.Set("state", state)
+	}
+	// Session enforcement (step-up auth) parameters, when requested.
+	if len(params.SessionRequiredIdentities) > 0 {
+		q.Set("session_required_identities", strings.Join(params.SessionRequiredIdentities, ","))
+	}
+	if len(params.SessionRequiredSingleDomain) > 0 {
+		q.Set("session_required_single_domain", strings.Join(params.SessionRequiredSingleDomain, ","))
+	}
+	if len(params.SessionRequiredPolicies) > 0 {
+		q.Set("session_required_policies", strings.Join(params.SessionRequiredPolicies, ","))
+	}
+	if params.SessionRequiredMFA {
+		q.Set("session_required_mfa", "true")
+	}
+	if params.SessionMessage != "" {
+		q.Set("session_message", params.SessionMessage)
 	}
 	return m.authBaseURL + "/v2/oauth2/authorize?" + q.Encode()
 }

--- a/v4/pkg/login/manager.go
+++ b/v4/pkg/login/manager.go
@@ -24,6 +24,17 @@ type AuthParams struct {
 
 	// State is an optional CSRF token embedded in the authorization URL.
 	State string
+
+	// Session enforcement parameters (Globus Auth "high assurance" / step-up
+	// auth). When set, they are emitted on the authorization URL so the login
+	// forces re-authentication of specific identities/domains/policies (the
+	// mechanism behind a CLI `session update`). See the Globus Auth Sessions
+	// guide; mirrors the fields on auth.AuthorizationURLOptions.
+	SessionRequiredIdentities   []string // session_required_identities
+	SessionRequiredSingleDomain []string // session_required_single_domain
+	SessionRequiredPolicies     []string // session_required_policies
+	SessionRequiredMFA          bool     // session_required_mfa
+	SessionMessage              string   // session_message
 }
 
 // LoginResult is returned by LoginFlowManager.RunLoginFlow after a successful


### PR DESCRIPTION
Threads Globus Auth session-enforcement (step-up auth) parameters through the
command-line login flow, so a caller can force re-authentication of specific
identities / domains / policies during login — the mechanism behind a CLI
`session update`.

- `login.AuthParams` gains `SessionRequiredIdentities`,
  `SessionRequiredSingleDomain`, `SessionRequiredPolicies`,
  `SessionRequiredMFA`, `SessionMessage`.
- `CommandLineLoginFlowManager.buildAuthURL` emits the corresponding
  `session_required_*` / `session_message` query params on the authorize URL.

These params already existed on `auth.AuthorizationURLOptions`; this just threads
them through the login-flow manager (backward-compatible additive change). Param
names verified against `GetAuthorizationURL`. Internal test asserts they appear
on the URL and are absent when unset. `ported` stays `v4.8.1`.