### PR TITLE
feat(v4): transfer CreateEndpoint (POST /v0.10/endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — transfer CreateEndpoint (v4 module)
+
+`transfer.Client.CreateEndpoint(ctx, doc)` does `POST /v0.10/endpoint` with a
+passthrough endpoint document. Setting `"is_globus_connect": true` registers a
+Globus Connect Personal (mapped) endpoint; the response carries a
+`globus_connect_setup_key`. Verified against globus-cli's `gcp create mapped`,
+which posts to the same path (upstream Python SDK has no typed `create_endpoint`
+— the CLI uses a raw `.post`). Unblocks a Go CLI `gcp create mapped` command.
+
 ### Added — session enforcement params on the login flow (v4 module)
 
 `login.AuthParams` gained `SessionRequiredIdentities`, `SessionRequiredSingleDomain`,

--- a/v4/pkg/services/transfer/client.go
+++ b/v4/pkg/services/transfer/client.go
@@ -60,6 +60,21 @@ func (c *Client) GetEndpoint(ctx context.Context, endpointID string) (*Endpoint,
 	return &endpoint, nil
 }
 
+// CreateEndpoint creates an endpoint (POST /v0.10/endpoint). doc is a
+// passthrough endpoint document. Setting "is_globus_connect": true registers a
+// Globus Connect Personal (mapped) endpoint; the response then carries a
+// "globus_connect_setup_key" used to configure an installed GCP agent.
+func (c *Client) CreateEndpoint(ctx context.Context, doc map[string]interface{}) (GenericResponse, error) {
+	if doc == nil {
+		return nil, &core.ValidationError{Field: "doc", Message: "endpoint document is required"}
+	}
+	var resp GenericResponse
+	if err := c.baseClient.DoRequest(ctx, http.MethodPost, "/v0.10/endpoint", nil, doc, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // UpdateEndpoint updates an endpoint (PUT /v0.10/endpoint/{id}). doc is a
 // passthrough endpoint document.
 func (c *Client) UpdateEndpoint(ctx context.Context, endpointID string, doc map[string]interface{}) (GenericResponse, error) {

--- a/v4/pkg/services/transfer/client_test.go
+++ b/v4/pkg/services/transfer/client_test.go
@@ -105,6 +105,46 @@ func TestGetEndpoint(t *testing.T) {
 	})
 }
 
+func TestCreateEndpoint(t *testing.T) {
+	t.Run("nil doc returns validation error", func(t *testing.T) {
+		server := testhelpers.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {})
+		client, err := transfer.NewClient(context.Background(), testhelpers.NewTestConfig(server.URL))
+		require.NoError(t, err)
+		defer client.Close()
+
+		_, err = client.CreateEndpoint(context.Background(), nil)
+		require.Error(t, err)
+		valErr, ok := err.(*core.ValidationError)
+		require.True(t, ok, "expected ValidationError, got %T", err)
+		assert.Equal(t, "doc", valErr.Field)
+	})
+
+	t.Run("GCP mapped create returns setup key", func(t *testing.T) {
+		server := testhelpers.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Contains(t, r.URL.Path, "/v0.10/endpoint")
+			testhelpers.RespondJSON(w, http.StatusCreated, map[string]interface{}{
+				"DATA_TYPE":                "endpoint_create_result",
+				"code":                     "Created",
+				"id":                       "new-gcp-ep",
+				"globus_connect_setup_key": "setup-key-123",
+			})
+		})
+		client, err := transfer.NewClient(context.Background(), testhelpers.NewTestConfig(server.URL))
+		require.NoError(t, err)
+		defer client.Close()
+
+		resp, err := client.CreateEndpoint(context.Background(), map[string]interface{}{
+			"DATA_TYPE":         "endpoint",
+			"display_name":      "My GCP",
+			"is_globus_connect": true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "new-gcp-ep", resp["id"])
+		assert.Equal(t, "setup-key-123", resp["globus_connect_setup_key"])
+	})
+}
+
 func TestSubmitTransfer(t *testing.T) {
 	t.Run("nil transfer returns validation error", func(t *testing.T) {
 		server := testhelpers.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {})


### PR DESCRIPTION
Adds `transfer.Client.CreateEndpoint(ctx, doc)` (POST `/v0.10/endpoint`, passthrough doc). With `is_globus_connect: true` it registers a GCP mapped endpoint and returns a `globus_connect_setup_key`. Verified against globus-cli's `gcp create mapped` (same path; upstream SDK has no typed create_endpoint). Unblocks a Go CLI `gcp create mapped`. Test added; `ported` stays v4.8.1.