### PR TITLE
fix(v4): implement PKCE in the login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — login flow now implements PKCE (v4 module)
+
+The command-line login flow performed the OAuth2 authorization-code exchange
+**without PKCE**, so it failed against public/native clients that require a
+`code_challenge` ("PKCE code_challenge required for client") — which includes
+modern Globus clients. `RunLoginFlow` now generates a `code_verifier`, sends
+`code_challenge` + `code_challenge_method=S256` on the authorize URL, and sends
+`code_verifier` in the token exchange (RFC 7636). This unblocks native-app login
+and the consent-escalation flows (e.g. `manage_projects`) against PKCE-enforcing
+clients. Found via globus-go-cli issue #32.
+
 ### Added — transfer CreateEndpoint (v4 module)
 
 `transfer.Client.CreateEndpoint(ctx, doc)` does `POST /v0.10/endpoint` with a

--- a/v4/pkg/login/authurl_internal_test.go
+++ b/v4/pkg/login/authurl_internal_test.go
@@ -23,7 +23,7 @@ func TestBuildAuthURLSessionParams(t *testing.T) {
 		SessionMessage:              "please re-authenticate",
 	}
 
-	raw := m.buildAuthURL(params.Scopes, "https://example.org/cb", "", params)
+	raw := m.buildAuthURL(params.Scopes, "https://example.org/cb", "", params, "challenge-abc")
 	u, err := parseQuery(raw)
 	if err != nil {
 		t.Fatalf("parse auth URL: %v", err)
@@ -35,6 +35,8 @@ func TestBuildAuthURLSessionParams(t *testing.T) {
 		"session_required_policies":      "pol-1",
 		"session_required_mfa":           "true",
 		"session_message":                "please re-authenticate",
+		"code_challenge":                 "challenge-abc",
+		"code_challenge_method":          "S256",
 	}
 	for k, want := range checks {
 		if got := u.Get(k); got != want {
@@ -42,10 +44,38 @@ func TestBuildAuthURLSessionParams(t *testing.T) {
 		}
 	}
 
-	// Absent when unset: a bare params object must emit no session_* keys.
-	bare := m.buildAuthURL([]string{"openid"}, "https://example.org/cb", "", AuthParams{Scopes: []string{"openid"}})
+	// Absent when unset: a bare params object (and no PKCE challenge) must emit
+	// no session_* or code_challenge keys.
+	bare := m.buildAuthURL([]string{"openid"}, "https://example.org/cb", "", AuthParams{Scopes: []string{"openid"}}, "")
 	if strings.Contains(bare, "session_required") || strings.Contains(bare, "session_message") {
 		t.Errorf("unexpected session params in URL with none set: %s", bare)
+	}
+	if strings.Contains(bare, "code_challenge") {
+		t.Errorf("unexpected code_challenge in URL when none set: %s", bare)
+	}
+}
+
+// TestPKCEVerifierAndChallenge checks the RFC 7636 S256 derivation: a known
+// verifier produces the documented challenge, and generated verifiers are
+// unique and URL-safe.
+func TestPKCEVerifierAndChallenge(t *testing.T) {
+	// RFC 7636 Appendix B worked example.
+	const rfcVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	const rfcChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	if got := pkceChallengeS256(rfcVerifier); got != rfcChallenge {
+		t.Errorf("pkceChallengeS256(RFC example) = %q, want %q", got, rfcChallenge)
+	}
+
+	v1, err := generatePKCEVerifier()
+	if err != nil {
+		t.Fatalf("generatePKCEVerifier: %v", err)
+	}
+	if len(v1) < 43 || len(v1) > 128 {
+		t.Errorf("verifier length %d out of RFC range 43-128", len(v1))
+	}
+	v2, _ := generatePKCEVerifier()
+	if v1 == v2 {
+		t.Error("consecutive verifiers should differ")
 	}
 }
 

--- a/v4/pkg/login/command_line.go
+++ b/v4/pkg/login/command_line.go
@@ -5,6 +5,9 @@ package login
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -84,7 +87,16 @@ func (m *CommandLineLoginFlowManager) RunLoginFlow(ctx context.Context, params A
 		redirectURI = params.RedirectURI
 	}
 
-	authURL := m.buildAuthURL(scopes, redirectURI, params.State, params)
+	// PKCE (RFC 7636): Globus requires a code_challenge for public/native
+	// clients. Generate a verifier, send its S256 challenge on the authorize
+	// URL, and the verifier in the token exchange.
+	verifier, err := generatePKCEVerifier()
+	if err != nil {
+		return nil, fmt.Errorf("login: generate PKCE verifier: %w", err)
+	}
+	challenge := pkceChallengeS256(verifier)
+
+	authURL := m.buildAuthURL(scopes, redirectURI, params.State, params, challenge)
 
 	fmt.Println("Please open the following URL in your browser to authenticate:")
 	fmt.Println()
@@ -104,11 +116,12 @@ func (m *CommandLineLoginFlowManager) RunLoginFlow(ctx context.Context, params A
 		return nil, fmt.Errorf("login: auth code is empty")
 	}
 
-	return m.exchangeCode(ctx, code, redirectURI)
+	return m.exchangeCode(ctx, code, redirectURI, verifier)
 }
 
-// buildAuthURL constructs the Globus Auth authorization URL.
-func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI, state string, params AuthParams) string {
+// buildAuthURL constructs the Globus Auth authorization URL. codeChallenge, when
+// non-empty, adds the PKCE (S256) challenge parameters.
+func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI, state string, params AuthParams, codeChallenge string) string {
 	q := url.Values{}
 	q.Set("response_type", "code")
 	q.Set("client_id", m.clientID)
@@ -118,6 +131,10 @@ func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI,
 	}
 	if state != "" {
 		q.Set("state", state)
+	}
+	if codeChallenge != "" {
+		q.Set("code_challenge", codeChallenge)
+		q.Set("code_challenge_method", "S256")
 	}
 	// Session enforcement (step-up auth) parameters, when requested.
 	if len(params.SessionRequiredIdentities) > 0 {
@@ -138,9 +155,27 @@ func (m *CommandLineLoginFlowManager) buildAuthURL(scopes []string, redirectURI,
 	return m.authBaseURL + "/v2/oauth2/authorize?" + q.Encode()
 }
 
+// generatePKCEVerifier returns a high-entropy PKCE code_verifier: 32 random
+// bytes base64url-encoded (43 chars), well within RFC 7636's 43–128 range and
+// using only unreserved characters.
+func generatePKCEVerifier() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// pkceChallengeS256 derives the S256 code_challenge from a verifier:
+// BASE64URL(SHA256(verifier)), no padding (RFC 7636 §4.2).
+func pkceChallengeS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
 // exchangeCode posts the authorization code to the token endpoint and parses
 // the response into a LoginResult.
-func (m *CommandLineLoginFlowManager) exchangeCode(ctx context.Context, code, redirectURI string) (*LoginResult, error) {
+func (m *CommandLineLoginFlowManager) exchangeCode(ctx context.Context, code, redirectURI, codeVerifier string) (*LoginResult, error) {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
@@ -148,6 +183,9 @@ func (m *CommandLineLoginFlowManager) exchangeCode(ctx context.Context, code, re
 	form.Set("redirect_uri", redirectURI)
 	if m.clientSecret != "" {
 		form.Set("client_secret", m.clientSecret)
+	}
+	if codeVerifier != "" {
+		form.Set("code_verifier", codeVerifier)
 	}
 
 	tokenURL := m.authBaseURL + "/v2/oauth2/token"


### PR DESCRIPTION
The command-line login flow did the OAuth2 code exchange **without PKCE**, so it failed against public/native clients requiring a `code_challenge` ("PKCE code_challenge required for client") — including modern Globus clients. `RunLoginFlow` now generates a `code_verifier`, sends `code_challenge`+`code_challenge_method=S256` on the authorize URL, and `code_verifier` in the token exchange (RFC 7636). Unblocks native-app login and consent-escalation (manage_projects, GCS data_access, session). Test uses the RFC 7636 worked example. Found via globus-go-cli #32; `ported` stays v4.8.1.