### PR TITLE
fix(auth): decode ProjectAdmins identities/groups as objects (closes #61)

### DIFF
--- a/v4/pkg/services/auth/models.go
+++ b/v4/pkg/services/auth/models.go
@@ -123,10 +123,30 @@ type Project struct {
 	LastUpdated   time.Time      `json:"last_updated"`
 }
 
-// ProjectAdmins is the expanded admins object on a project.
+// ProjectAdmins is the expanded admins object on a project. The Globus Auth
+// Projects API returns identities and groups as arrays of objects (not ID
+// strings); the string ID arrays live on Project.AdminIDs/AdminGroupIDs.
 type ProjectAdmins struct {
-	Identities []string `json:"identities"`
-	Groups     []string `json:"groups"`
+	Identities []ProjectAdminIdentity `json:"identities"`
+	Groups     []ProjectAdminGroup    `json:"groups"`
+}
+
+// ProjectAdminIdentity is an expanded admin identity in ProjectAdmins.Identities.
+type ProjectAdminIdentity struct {
+	ID               string `json:"id"`
+	Username         string `json:"username"`
+	Name             string `json:"name"`
+	Email            string `json:"email"`
+	IdentityProvider string `json:"identity_provider"`
+	IdentityType     string `json:"identity_type"`
+	Organization     string `json:"organization"`
+	Status           string `json:"status"`
+}
+
+// ProjectAdminGroup is an expanded admin group in ProjectAdmins.Groups.
+type ProjectAdminGroup struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // ProjectCreate is the create-project body (nested under a "project" key on the

--- a/v4/pkg/services/auth/project_admins_test.go
+++ b/v4/pkg/services/auth/project_admins_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package auth_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/scttfrdmn/globus-go-sdk/v4/pkg/services/auth"
+)
+
+// TestProjectAdminsDecode is a regression test for issue #61: the Globus Auth
+// Projects API returns admins.identities (and admins.groups) as arrays of
+// objects, not ID strings. The previous []string typing failed to decode any
+// project carrying the expanded admins object, blocking `project list`/`show`.
+func TestProjectAdminsDecode(t *testing.T) {
+	// Shape taken from docs.globus.org/api/auth/reference (Projects Resource).
+	body := `{
+		"id": "927c2fbf-e962-4207-8f8e-2c48e7fd3f00",
+		"display_name": "Demo Project",
+		"contact_email": "admin@example.org",
+		"admin_ids": ["ae341a98-d274-11e5-b888-dbae3a8ba545"],
+		"admins": {
+			"identities": [
+				{
+					"id": "ae341a98-d274-11e5-b888-dbae3a8ba545",
+					"username": "admin@example.org",
+					"name": "Demo Admin",
+					"email": "admin@example.org",
+					"identity_provider": "927d7238-f917-4eb2-9ace-c523a2af1234",
+					"identity_type": "login",
+					"organization": "Example Org",
+					"status": "used"
+				}
+			],
+			"groups": []
+		}
+	}`
+
+	var p auth.Project
+	if err := json.Unmarshal([]byte(body), &p); err != nil {
+		t.Fatalf("failed to decode project with expanded admins: %v", err)
+	}
+
+	if p.Admins == nil {
+		t.Fatal("expected admins object to be populated")
+	}
+	if len(p.Admins.Identities) != 1 {
+		t.Fatalf("expected 1 admin identity, got %d", len(p.Admins.Identities))
+	}
+	got := p.Admins.Identities[0]
+	if got.Username != "admin@example.org" || got.IdentityType != "login" || got.Organization != "Example Org" {
+		t.Errorf("admin identity fields not decoded correctly: %+v", got)
+	}
+	if got.ID != "ae341a98-d274-11e5-b888-dbae3a8ba545" {
+		t.Errorf("admin identity ID = %q, want the identity UUID", got.ID)
+	}
+
+	// A populated group object must also decode (docs show groups empty, but the
+	// field is an object array, not a string array).
+	groupBody := `{"identities": [], "groups": [{"id": "g-123", "name": "Admins"}]}`
+	var admins auth.ProjectAdmins
+	if err := json.Unmarshal([]byte(groupBody), &admins); err != nil {
+		t.Fatalf("failed to decode admins with group object: %v", err)
+	}
+	if len(admins.Groups) != 1 || admins.Groups[0].Name != "Admins" {
+		t.Errorf("admin group not decoded correctly: %+v", admins.Groups)
+	}
+}


### PR DESCRIPTION
## Problem
`globus project list` (globus-go-cli) fails right after auth with:
```
json: cannot unmarshal object into Go struct field ProjectAdmins.projects.admins.identities of type string
```

The Globus Auth Projects API returns `admins.identities` and `admins.groups` as **arrays of objects**, but `ProjectAdmins` typed both as `[]string`, so any project carrying the expanded `admins` object failed to decode — blocking the whole `project` command tree.

## Fix
- Add `ProjectAdminIdentity` (`id`, `username`, `name`, `email`, `identity_provider`, `identity_type`, `organization`, `status` — per [docs.globus.org/api/auth/reference](https://docs.globus.org/api/auth/reference/)) and `ProjectAdminGroup` (`id`, `name`).
- Use them in `ProjectAdmins.Identities`/`.Groups`.
- `Project.AdminIDs []string` (`admin_ids`) is unchanged — that field genuinely is a string array; only the expanded `admins` object was mistyped.

## Test
Adds `TestProjectAdminsDecode` decoding the documented object-array shape (the exact payload that previously failed), plus a populated group object. `go vet` + full auth package tests pass.

Closes #61.