### PR TITLE
fix(core): populate APIError.Details from body, not a re-read (closes #63)

### DIFF
--- a/v4/pkg/core/errors.go
+++ b/v4/pkg/core/errors.go
@@ -69,7 +69,11 @@ func (e *APIError) IsServerError() bool {
 	return e.StatusCode >= 500 && e.StatusCode < 600
 }
 
-// NewAPIError creates a new APIError from an HTTP response
+// NewAPIError creates a new APIError from an HTTP response. The message
+// argument is the already-read response body (the caller reads resp.Body to
+// produce it); NewAPIError parses that string for structured fields rather than
+// re-reading resp.Body, which by this point is drained. See issue #63: the old
+// code decoded resp.Body a second time, always hit io.EOF, and left Details nil.
 func NewAPIError(resp *http.Response, message string) *APIError {
 	apiErr := &APIError{
 		StatusCode:   resp.StatusCode,
@@ -78,27 +82,52 @@ func NewAPIError(resp *http.Response, message string) *APIError {
 		HTTPResponse: resp,
 	}
 
-	// Try to parse error response body
-	if resp.Body != nil {
-		var errorBody map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&errorBody); err == nil {
-			// Extract common error fields
-			if code, ok := errorBody["code"].(string); ok {
-				apiErr.Code = code
+	// Parse the body (passed in as message) for structured error fields.
+	var errorBody map[string]interface{}
+	if err := json.Unmarshal([]byte(message), &errorBody); err == nil {
+		// Extract common top-level error fields.
+		if code, ok := errorBody["code"].(string); ok {
+			apiErr.Code = code
+		}
+		if msg, ok := errorBody["message"].(string); ok && msg != "" {
+			apiErr.Message = msg
+		}
+		if resource, ok := errorBody["resource"].(string); ok {
+			apiErr.Resource = resource
+		}
+
+		// Some Globus errors (e.g. Auth) nest the details under errors[0]
+		// rather than at the top level; fall back to the first sub-error for
+		// code/message when the top-level fields are absent.
+		if sub, ok := firstSubError(errorBody); ok {
+			if apiErr.Code == "" {
+				if code, ok := sub["code"].(string); ok {
+					apiErr.Code = code
+				}
 			}
-			if msg, ok := errorBody["message"].(string); ok && msg != "" {
+			if msg, ok := sub["message"].(string); ok && msg != "" && apiErr.Message == message {
 				apiErr.Message = msg
 			}
-			if resource, ok := errorBody["resource"].(string); ok {
-				apiErr.Resource = resource
-			}
-
-			// Store all additional details
-			apiErr.Details = errorBody
 		}
+
+		// Store the full parsed body for consumers that need nested fields
+		// (e.g. authorization_parameters.session_required_policies).
+		apiErr.Details = errorBody
 	}
 
 	return apiErr
+}
+
+// firstSubError returns the first element of a top-level "errors" array as a
+// map, if present. Globus Auth returns error details in this JSON:API-style
+// shape (`{"errors":[{"code":...,"detail":...}]}`).
+func firstSubError(body map[string]interface{}) (map[string]interface{}, bool) {
+	errs, ok := body["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		return nil, false
+	}
+	sub, ok := errs[0].(map[string]interface{})
+	return sub, ok
 }
 
 // ValidationError represents a client-side validation error

--- a/v4/pkg/core/errors_test.go
+++ b/v4/pkg/core/errors_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+package core
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// mkResp builds a minimal *http.Response with a drained-equivalent body, to
+// mirror the real call path where the caller has already read resp.Body before
+// calling NewAPIError.
+func mkResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{},
+		// Body is intentionally an empty reader: NewAPIError must parse the
+		// message argument, not re-read this (issue #63).
+		Body: io.NopCloser(strings.NewReader("")),
+	}
+}
+
+// TestNewAPIErrorPopulatesDetails is the regression test for issue #63:
+// NewAPIError must populate Details from the body passed as message, rather than
+// re-reading the already-drained resp.Body (which yielded io.EOF and left
+// Details nil — breaking the session_required_policies retry in globus-go-cli).
+func TestNewAPIErrorPopulatesDetails(t *testing.T) {
+	body := `{
+		"code": "FORBIDDEN",
+		"message": "high assurance required",
+		"authorization_parameters": {
+			"session_required_policies": ["34285468-cba9-4615-a719-eff66d292409"]
+		}
+	}`
+	resp := mkResp(http.StatusForbidden, body)
+
+	apiErr := NewAPIError(resp, body)
+
+	if apiErr.Details == nil {
+		t.Fatal("Details is nil — body was not parsed (issue #63 regression)")
+	}
+	if apiErr.Code != "FORBIDDEN" {
+		t.Errorf("Code = %q, want FORBIDDEN", apiErr.Code)
+	}
+	if apiErr.Message != "high assurance required" {
+		t.Errorf("Message = %q, want the parsed message", apiErr.Message)
+	}
+
+	ap, ok := apiErr.Details["authorization_parameters"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("authorization_parameters missing from Details: %#v", apiErr.Details)
+	}
+	pols, ok := ap["session_required_policies"].([]interface{})
+	if !ok || len(pols) != 1 || pols[0] != "34285468-cba9-4615-a719-eff66d292409" {
+		t.Errorf("session_required_policies not extracted: %#v", ap["session_required_policies"])
+	}
+}
+
+// TestNewAPIErrorNestedErrors covers the JSON:API-style shape Globus Auth uses,
+// where code/message live under errors[0] rather than at the top level (issue
+// #63 fix #3).
+func TestNewAPIErrorNestedErrors(t *testing.T) {
+	body := `{"errors":[{"code":"FORBIDDEN","message":"nested detail"}]}`
+	resp := mkResp(http.StatusForbidden, body)
+
+	apiErr := NewAPIError(resp, body)
+
+	if apiErr.Code != "FORBIDDEN" {
+		t.Errorf("Code = %q, want FORBIDDEN from errors[0]", apiErr.Code)
+	}
+	if apiErr.Message != "nested detail" {
+		t.Errorf("Message = %q, want the nested message", apiErr.Message)
+	}
+	if apiErr.Details == nil {
+		t.Error("Details should be populated for nested-error bodies")
+	}
+}
+
+// TestNewAPIErrorNonJSONBody verifies a non-JSON body is preserved verbatim as
+// Message and leaves Details nil (no panic, no garbage).
+func TestNewAPIErrorNonJSONBody(t *testing.T) {
+	body := "502 Bad Gateway"
+	resp := mkResp(http.StatusBadGateway, body)
+
+	apiErr := NewAPIError(resp, body)
+
+	if apiErr.Message != body {
+		t.Errorf("Message = %q, want the raw body preserved", apiErr.Message)
+	}
+	if apiErr.Details != nil {
+		t.Errorf("Details should be nil for a non-JSON body, got %#v", apiErr.Details)
+	}
+	if apiErr.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want 502", apiErr.StatusCode)
+	}
+}


### PR DESCRIPTION
## Problem
`APIError.Details` was always `nil` for error responses with a JSON body, and the raw body leaked into `APIError.Message`.

`NewAPIError(resp, message)` tried to `json.NewDecoder(resp.Body).Decode(...)`, but the sole caller (`client.go` `doRequest`) had already read `resp.Body` via `io.ReadAll` to build the `message` argument. The second read hit `io.EOF`, so the `err == nil` block — including `apiErr.Details = errorBody` — was never reached.

This broke every consumer of `Details`, notably **globus-go-cli#41**'s `session_required_policies` retry: the CLI caught the 403 but `Details["authorization_parameters"]` was nil, so it never re-authenticated against a policy-protected project.

## Fix
- Parse the `message` string (which **is** the body the caller read) instead of re-reading `resp.Body`. Single read, no EOF.
- Extract `code`/`message` from `errors[0]` as a fallback for the JSON:API-style nested-error shape Globus Auth returns (issue fix #3).
- Non-JSON bodies are preserved verbatim as `Message` with `Details` nil.

## Tests
`TestNewAPIErrorPopulatesDetails` (the exact 403 `authorization_parameters.session_required_policies` body), `TestNewAPIErrorNestedErrors` (errors[] shape), `TestNewAPIErrorNonJSONBody`. Full `pkg/core` + whole-v4-module tests + vet pass.

Closes #63. Unblocks globus-go-cli#41 end-to-end.